### PR TITLE
Migrate module instructions from root README into per-module READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,327 +91,59 @@ See [RUNNING.md](./RUNNING.md) for more information.
 
 ## Manual Method
 
-If you prefer, you can still build the modules manually. Below are the steps for each module:
+If you prefer, you can still build the modules manually. Each module's README.md
+contains the module-specific build commands, dependencies, and notes.
 
 ### Bitcoin modules:
 
-- ### [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin)
-
-    ```bash
-    cd modules/rustbitcoin
-    make
-    export CXXFLAGS="$CXXFLAGS -DRUST_BITCOIN"
-    ```
-
-- ### [tinyminiscript](https://github.com/unldenis/tinyminiscript)
-
-    ```bash
-    cd modules/tinyminiscript
-    make
-    export CXXFLAGS="$CXXFLAGS -DTINY_MINISCRIPT"
-    ```
-
-- ### [rust-miniscript](https://github.com/rust-bitcoin/rust-miniscript)
-
-    ```bash
-    cd modules/rustminiscript
-    make
-    export CXXFLAGS="$CXXFLAGS -DRUST_MINISCRIPT"
-    ```
-
-- ### [bitcoinerlab miniscript](https://github.com/bitcoinerlab/miniscript)
-
-    Requires QuickJS installed. By default, the module looks for a complete QuickJS install under `/usr/local` or `/usr`.
-
-    ```bash
-    sudo apt-get install quickjs libquickjs
-    cd modules/bitcoinerlabminiscript
-    make
-    export CXXFLAGS="$CXXFLAGS -DBITCOINERLAB_MINISCRIPT"
-    ```
-
-- ### [btcd](https://github.com/btcsuite/btcd)
-
-    ```bash
-    cd modules/btcd
-    make
-    export CXXFLAGS="$CXXFLAGS -DBTCD"
-    ```
-
-- ### [gocoin](https://github.com/piotrnar/gocoin)
-
-    [gocoin](https://github.com/piotrnar/gocoin) is a full Bitcoin node implementation written in Go.
-
-    ```bash
-    cd modules/gocoin
-    make
-    export CXXFLAGS="$CXXFLAGS -DGOCOIN"
-    ```
-
-    **Note:** gocoin cannot be used together with btcd in the same build due to cgo symbol conflicts (both embed the Go runtime).
-
-- ### [NBitcoin](https://github.com/MetacoSA/NBitcoin)
-
-    ```bash
-    cd modules/nbitcoin
-    make
-    export CXXFLAGS="$CXXFLAGS -DNBITCOIN"
-    ```
-
-- ### [embit](https://github.com/diybitcoinhardware/embit)
-
-    To run the fuzzer with `embit` module, you need to install the `embit` library.
-
-    To install the `embit` library, you can use the following command:
-    ```bash
-    cd modules/embit
-    pip install -r ./requirements.txt
-    ```
-
-    ```bash
-    cd modules/embit
-    make
-    export CXXFLAGS="$CXXFLAGS -DEMBIT"
-    ```
-
-- ### [rust-bitcoinkernel](https://github.com/sedited/rust-bitcoinkernel)
-
-    ```bash
-    cd modules/rustbitcoinkernel
-    make
-    export CXXFLAGS="$CXXFLAGS -DRUSTBITCOINKERNEL"
-    ```
-
-- ### [py-bitcoinkernel](https://github.com/stickies-v/py-bitcoinkernel)
-
-    To run the fuzzer with `py-bitcoinkernel` module, you need to install the `py-bitcoinkernel` library.
-
-    To install the `py-bitcoinkernel` library, you can use the following command:
-    ```bash
-    cd modules/pybitcoinkernel
-    pip install -r ./requirements.txt
-    ```
-
-    ```bash
-    cd modules/pybitcoinkernel
-    make
-    export CXXFLAGS="$CXXFLAGS -DPYBITCOINKERNEL"
-    ```
-
-- ### [bitcoinkernel](https://github.com/bitcoin/bitcoin/blob/master/src/kernel/bitcoinkernel.cpp) (Bitcoin Core's [`libbitcoinkernel`](https://github.com/bitcoin/bitcoin/issues/27587) project)
-
-    Use this module when you want to run kernel fuzz targets against **a single** `libbitcoinkernel` version.
-
-    - **Default version**: `master`
-    - **Pin a version**: set `BITCOINKERNEL_REF` (tag/branch/commit)
-
-    ```bash
-    # build manual (default: master)
-    cd modules/bitcoinkernel
-    export BITCOINKERNEL_REF=[ref]
-    make
-    export CXXFLAGS="$CXXFLAGS -DBITCOINKERNEL"
-- ### bitcoinkernel-variant (differential fuzzing for `libbitcoinkernel`)
-
-    For differential fuzzing between two bitcoinkernel versions, build **two** modules:
-    - `BITCOINKERNEL` (base; `BITCOINKERNEL_REF`, default `master`)
-    - `BITCOINKERNEL_VARIANT` (comparison; `BITCOINKERNEL_VARIANT_REF`, default `master`)
-
-    ```bash
-    # 1) base (creates the reference repo at modules/bitcoinkernel/bitcoin)
-    cd modules/bitcoinkernel
-    export BITCOINKERNEL_REF=[base_ref]
-    make
-    export CXXFLAGS="$CXXFLAGS -DBITCOINKERNEL"
-
-    # 2) variant (ref repo is required for build)
-    cd ../bitcoinkernelvariant
-    BITCOINKERNEL_VARIANT_REF=<variant_ref>
-    make
-    export CXXFLAGS="$CXXFLAGS -DBITCOINKERNEL_VARIANT"
-    ```
-
-- ### [Bitcoin Core](https://github.com/bitcoin/bitcoin)
-
-    ```bash
-    git submodule update --init external/bitcoin-core
-    cd modules/bitcoin
-    make
-    export CXXFLAGS="$CXXFLAGS -DBITCOIN_CORE"
-    ```
-
-    To update to a newer Bitcoin Core version:
-    ```bash
-    git submodule update --remote external/bitcoin-core
-    cd modules/bitcoin && make clean && make
-    ```
-
-- ### [bitcoinj](https://github.com/bitcoinj/bitcoinj)
-
-    ```bash
-    cd modules/bitcoinj
-    make
-    export CXXFLAGS="$CXXFLAGS -DBITCOINJ"
-    ```
-
-- ### [bitcoin-s](https://github.com/bitcoin-s/bitcoin-s)
-
-    ```bash
-    cd modules/bitcoins
-    make
-    export CXXFLAGS="$CXXFLAGS -DBITCOINS"
-    ```
-
-- ### [libwally-core](https://github.com/ElementsProject/libwally-core)
-
-    ```bash
-    git submodule update --init --recursive external/libwally-core
-    cd modules/libwallycore
-    make
-    export CXXFLAGS="$CXXFLAGS -DLIBWALLY_CORE"
-    ```
-
-- ### [libbitcoin-system](https://github.com/libbitcoin/libbitcoin-system)
-
-    Requires Boost (>= 1.86), CMake (>= 3.30), and binutils (`objcopy`). On Debian/Ubuntu: `apt-get install libboost-all-dev cmake binutils`.
-
-    ```bash
-    git submodule update --init --recursive external/libbitcoin-system external/secp256k1
-    cd modules/libbitcoinsystem
-    make
-    export CXXFLAGS="$CXXFLAGS -DLIBBITCOIN_SYSTEM"
-    ```
-
-- ### [pycoin](https://github.com/richardkiss/pycoin)
-
-    To run the fuzzer with `pycoin` module, you need to install the `pycoin` library.
-
-    To install the `pycoin` library, you can use the following command:
-    ```bash
-    cd modules/pycoin
-    pip install -r ./requirements.txt
-    ```
-
-    ```bash
-    cd modules/pycoin
-    make
-    export CXXFLAGS="$CXXFLAGS -DPYCOIN"
-    ```
+| Module | CXXFLAGS define | Instructions |
+| --- | --- | --- |
+| [Bitcoin Core](https://github.com/bitcoin/bitcoin) | `BITCOIN_CORE` | [modules/bitcoin/README.md](./modules/bitcoin/README.md) |
+| [bitcoinerlab miniscript](https://github.com/bitcoinerlab/miniscript) | `BITCOINERLAB_MINISCRIPT` | [modules/bitcoinerlabminiscript/README.md](./modules/bitcoinerlabminiscript/README.md) |
+| [bitcoinj](https://github.com/bitcoinj/bitcoinj) | `BITCOINJ` | [modules/bitcoinj/README.md](./modules/bitcoinj/README.md) |
+| [bitcoinkernel](https://github.com/bitcoin/bitcoin/blob/master/src/kernel/bitcoinkernel.cpp) | `BITCOINKERNEL` | [modules/bitcoinkernel/README.md](./modules/bitcoinkernel/README.md) |
+| bitcoinkernel-variant | `BITCOINKERNEL_VARIANT` | [modules/bitcoinkernelvariant/README.md](./modules/bitcoinkernelvariant/README.md) |
+| [bitcoin-s](https://github.com/bitcoin-s/bitcoin-s) | `BITCOINS` | [modules/bitcoins/README.md](./modules/bitcoins/README.md) |
+| [btcd](https://github.com/btcsuite/btcd) | `BTCD` | [modules/btcd/README.md](./modules/btcd/README.md) |
+| [embit](https://github.com/diybitcoinhardware/embit) | `EMBIT` | [modules/embit/README.md](./modules/embit/README.md) |
+| [gocoin](https://github.com/piotrnar/gocoin) | `GOCOIN` | [modules/gocoin/README.md](./modules/gocoin/README.md) |
+| [libbitcoin-system](https://github.com/libbitcoin/libbitcoin-system) | `LIBBITCOIN_SYSTEM` | [modules/libbitcoinsystem/README.md](./modules/libbitcoinsystem/README.md) |
+| [libwally-core](https://github.com/ElementsProject/libwally-core) | `LIBWALLY_CORE` | [modules/libwallycore/README.md](./modules/libwallycore/README.md) |
+| [NBitcoin](https://github.com/MetacoSA/NBitcoin) | `NBITCOIN` | [modules/nbitcoin/README.md](./modules/nbitcoin/README.md) |
+| [py-bitcoinkernel](https://github.com/stickies-v/py-bitcoinkernel) | `PYBITCOINKERNEL` | [modules/pybitcoinkernel/README.md](./modules/pybitcoinkernel/README.md) |
+| [pycoin](https://github.com/richardkiss/pycoin) | `PYCOIN` | [modules/pycoin/README.md](./modules/pycoin/README.md) |
+| [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin) | `RUST_BITCOIN` | [modules/rustbitcoin/README.md](./modules/rustbitcoin/README.md) |
+| [rust-bitcoinkernel](https://github.com/sedited/rust-bitcoinkernel) | `RUSTBITCOINKERNEL` | [modules/rustbitcoinkernel/README.md](./modules/rustbitcoinkernel/README.md) |
+| [rust-miniscript](https://github.com/rust-bitcoin/rust-miniscript) | `RUST_MINISCRIPT` | [modules/rustminiscript/README.md](./modules/rustminiscript/README.md) |
+| [rust-psbt](https://github.com/rust-bitcoin/rust-psbt) | `RUST_PSBT` | [modules/rustpsbt/README.md](./modules/rustpsbt/README.md) |
+| [tinyminiscript](https://github.com/unldenis/tinyminiscript) | `TINY_MINISCRIPT` | [modules/tinyminiscript/README.md](./modules/tinyminiscript/README.md) |
 
 ### Lightning modules:
 
-- ### [LDK](https://github.com/lightningdevkit/rust-lightning)
-
-    ```bash
-    cd modules/ldk
-    make
-    export CXXFLAGS="$CXXFLAGS -DLDK"
-    ```
-
-- ### [LND](https://github.com/lightningnetwork/lnd)
-
-    ```bash
-    cd modules/lnd
-    make
-    export CXXFLAGS="$CXXFLAGS -DLND"
-    ```
-
-- ### [NLightning](https://github.com/ipms-io/nlightning)
-
-    ```bash
-    cd modules/nlightning
-    make
-    export CXXFLAGS="$CXXFLAGS -DNLIGHTNING"
-    ```
-
-- ### [C-lightning](https://github.com/ElementsProject/lightning)
-
-    ```bash
-    pip install mako
-    git submodule update --init --recursive external/lightning
-    cd modules/clightning
-    make
-    export CXXFLAGS="$CXXFLAGS -DCLIGHTNING"
-    ```
-
-- ### [Eclair](https://github.com/ACINQ/eclair)
-
-    ```bash
-    git submodule update --init --recursive external/eclair
-    cd modules/eclair
-    make
-    export CXXFLAGS="$CXXFLAGS -DECLAIR"
-    ```
-
-    **Note:** When fuzzing with Eclair, the JVM's JIT compiler allocates memory that LSan cannot track through the standard allocator, causing false-positive leak reports. Use the provided suppressions file to silence them:
-
-    ```bash
-    LSAN_OPTIONS="suppressions=$(pwd)/lsan.supp" FUZZ=deserialize_invoice ./bitcoinfuzz
-    LSAN_OPTIONS="suppressions=$(pwd)/lsan.supp" FUZZ=deserialize_offer ./bitcoinfuzz
-    ```
-    
-    This suppressions file was only validated on Ubuntu and might not work depending on your setup. You can write your own file or disable the leak detection globally.
-
-- ### [lightning-kmp](https://github.com/ACINQ/lightning-kmp)
-
-    ```bash
-    cd modules/lightningkmp
-    make
-    export CXXFLAGS="$CXXFLAGS -DLIGHTNING_KMP"
-    ```
+| Module | CXXFLAGS define | Instructions |
+| --- | --- | --- |
+| [C-lightning](https://github.com/ElementsProject/lightning) | `CLIGHTNING` | [modules/clightning/README.md](./modules/clightning/README.md) |
+| [Eclair](https://github.com/ACINQ/eclair) | `ECLAIR` | [modules/eclair/README.md](./modules/eclair/README.md) |
+| [LDK](https://github.com/lightningdevkit/rust-lightning) | `LDK` | [modules/ldk/README.md](./modules/ldk/README.md) |
+| [lightning-kmp](https://github.com/ACINQ/lightning-kmp) | `LIGHTNING_KMP` | [modules/lightningkmp/README.md](./modules/lightningkmp/README.md) |
+| [LND](https://github.com/lightningnetwork/lnd) | `LND` | [modules/lnd/README.md](./modules/lnd/README.md) |
+| [NLightning](https://github.com/ipms-io/nlightning) | `NLIGHTNING` | [modules/nlightning/README.md](./modules/nlightning/README.md) |
 
 ### Secp256k1 modules:
 
-- ### [Decred-Secp256k1](https://github.com/decred/dcrd/tree/master/dcrec/secp256k1)
-
-    ```bash
-    cd modules/decredsecp256k1
-    make
-    export CXXFLAGS="$CXXFLAGS -DDECRED_SECP256K1"
-    ```
-
-- ### [Libsecp256k1](https://github.com/bitcoin-core/secp256k1)
-
-    ```bash
-    git submodule update --init --recursive external/secp256k1
-    cd modules/secp256k1
-    make
-    export CXXFLAGS="$CXXFLAGS -DSECP256K1"
-    ```
-
-- ### [NBitcoin-Secp256k1](https://github.com/MetacoSA/NBitcoin/tree/master/NBitcoin.Secp256k1)
-
-    ```bash
-    cd modules/nbitcoinsecp256k1
-    make
-    export CXXFLAGS="$CXXFLAGS -DNBITCOIN_SECP256K1"
-    ```
-
-- ### [K256](https://github.com/RustCrypto/elliptic-curves/tree/master/k256)
-
-    ```bash
-    cd modules/rustk256
-    make
-    export CXXFLAGS="$CXXFLAGS -DRUST_K256"
-    ```
+| Module | CXXFLAGS define | Instructions |
+| --- | --- | --- |
+| [Decred-Secp256k1](https://github.com/decred/dcrd/tree/master/dcrec/secp256k1) | `DECRED_SECP256K1` | [modules/decredsecp256k1/README.md](./modules/decredsecp256k1/README.md) |
+| [K256](https://github.com/RustCrypto/elliptic-curves/tree/master/k256) | `RUST_K256` | [modules/rustk256/README.md](./modules/rustk256/README.md) |
+| [Libsecp256k1](https://github.com/bitcoin-core/secp256k1) | `SECP256K1` | [modules/secp256k1/README.md](./modules/secp256k1/README.md) |
+| [NBitcoin-Secp256k1](https://github.com/MetacoSA/NBitcoin/tree/master/NBitcoin.Secp256k1) | `NBITCOIN_SECP256K1` | [modules/nbitcoinsecp256k1/README.md](./modules/nbitcoinsecp256k1/README.md) |
 
 ### Utreexo Modules
 
-- ### [Utreexo](https://github.com/utreexo/utreexo)
-
-    ```bash
-    cd modules/utreexo
-    make
-    export CXXFLAGS="$CXXFLAGS -DUTREEXO"
-    ```
-
-- ### [Rustreexo](https://github.com/mit-dci/rustreexo)
-
-    ```bash
-    cd modules/rustreexo
-    make
-    export CXXFLAGS="$CXXFLAGS -DRUSTREEXO"
-    ```
+| Module | CXXFLAGS define | Instructions |
+| --- | --- | --- |
+| [Rustreexo](https://github.com/mit-dci/rustreexo) | `RUSTREEXO` | [modules/rustreexo/README.md](./modules/rustreexo/README.md) |
+| [Utreexo](https://github.com/utreexo/utreexo) | `UTREEXO` | [modules/utreexo/README.md](./modules/utreexo/README.md) |
 
 ## Final Build and Execution
 Once the modules are compiled, you can compile `bitcoinfuzz` and execute it:

--- a/modules/bitcoin/README.md
+++ b/modules/bitcoin/README.md
@@ -1,0 +1,19 @@
+# Bitcoin Core module
+
+Upstream: [Bitcoin Core](https://github.com/bitcoin/bitcoin)
+
+## Build
+
+```bash
+git submodule update --init external/bitcoin-core
+cd modules/bitcoin
+make
+export CXXFLAGS="$CXXFLAGS -DBITCOIN_CORE"
+```
+
+To update to a newer Bitcoin Core version:
+
+```bash
+git submodule update --remote external/bitcoin-core
+cd modules/bitcoin && make clean && make
+```

--- a/modules/bitcoinj/README.md
+++ b/modules/bitcoinj/README.md
@@ -1,0 +1,11 @@
+# bitcoinj module
+
+Upstream: [bitcoinj](https://github.com/bitcoinj/bitcoinj)
+
+## Build
+
+```bash
+cd modules/bitcoinj
+make
+export CXXFLAGS="$CXXFLAGS -DBITCOINJ"
+```

--- a/modules/bitcoinkernel/README.md
+++ b/modules/bitcoinkernel/README.md
@@ -1,0 +1,18 @@
+# bitcoinkernel module
+
+Upstream: [Bitcoin Core libbitcoinkernel](https://github.com/bitcoin/bitcoin/blob/master/src/kernel/bitcoinkernel.cpp)
+
+Use this module when you want to run kernel fuzz targets against a single
+`libbitcoinkernel` version.
+
+- Default version: `master`
+- Pin a version: set `BITCOINKERNEL_REF` to a tag, branch, or commit
+
+## Build
+
+```bash
+cd modules/bitcoinkernel
+export BITCOINKERNEL_REF=[ref]
+make
+export CXXFLAGS="$CXXFLAGS -DBITCOINKERNEL"
+```

--- a/modules/bitcoinkernelvariant/README.md
+++ b/modules/bitcoinkernelvariant/README.md
@@ -1,0 +1,25 @@
+# bitcoinkernel-variant module
+
+This module is used for differential fuzzing between two `libbitcoinkernel`
+versions.
+
+For differential fuzzing between two bitcoinkernel versions, build two modules:
+
+- `BITCOINKERNEL` (base; `BITCOINKERNEL_REF`, default `master`)
+- `BITCOINKERNEL_VARIANT` (comparison; `BITCOINKERNEL_VARIANT_REF`, default `master`)
+
+## Build
+
+```bash
+# 1) base (creates the reference repo at modules/bitcoinkernel/bitcoin)
+cd modules/bitcoinkernel
+export BITCOINKERNEL_REF=[base_ref]
+make
+export CXXFLAGS="$CXXFLAGS -DBITCOINKERNEL"
+
+# 2) variant (ref repo is required for build)
+cd ../bitcoinkernelvariant
+BITCOINKERNEL_VARIANT_REF=<variant_ref>
+make
+export CXXFLAGS="$CXXFLAGS -DBITCOINKERNEL_VARIANT"
+```

--- a/modules/bitcoins/README.md
+++ b/modules/bitcoins/README.md
@@ -1,0 +1,11 @@
+# bitcoin-s module
+
+Upstream: [bitcoin-s](https://github.com/bitcoin-s/bitcoin-s)
+
+## Build
+
+```bash
+cd modules/bitcoins
+make
+export CXXFLAGS="$CXXFLAGS -DBITCOINS"
+```

--- a/modules/btcd/README.md
+++ b/modules/btcd/README.md
@@ -1,0 +1,11 @@
+# btcd module
+
+Upstream: [btcd](https://github.com/btcsuite/btcd)
+
+## Build
+
+```bash
+cd modules/btcd
+make
+export CXXFLAGS="$CXXFLAGS -DBTCD"
+```

--- a/modules/clightning/README.md
+++ b/modules/clightning/README.md
@@ -1,0 +1,13 @@
+# C-lightning module
+
+Upstream: [Core Lightning](https://github.com/ElementsProject/lightning)
+
+## Build
+
+```bash
+pip install mako
+git submodule update --init --recursive external/lightning
+cd modules/clightning
+make
+export CXXFLAGS="$CXXFLAGS -DCLIGHTNING"
+```

--- a/modules/decredsecp256k1/README.md
+++ b/modules/decredsecp256k1/README.md
@@ -1,0 +1,11 @@
+# Decred-Secp256k1 module
+
+Upstream: [Decred-Secp256k1](https://github.com/decred/dcrd/tree/master/dcrec/secp256k1)
+
+## Build
+
+```bash
+cd modules/decredsecp256k1
+make
+export CXXFLAGS="$CXXFLAGS -DDECRED_SECP256K1"
+```

--- a/modules/eclair/README.md
+++ b/modules/eclair/README.md
@@ -1,0 +1,27 @@
+# Eclair module
+
+Upstream: [Eclair](https://github.com/ACINQ/eclair)
+
+## Build
+
+```bash
+git submodule update --init --recursive external/eclair
+cd modules/eclair
+make
+export CXXFLAGS="$CXXFLAGS -DECLAIR"
+```
+
+## Notes
+
+When fuzzing with Eclair, the JVM's JIT compiler allocates memory that LSan
+cannot track through the standard allocator, causing false-positive leak
+reports. Use the provided suppressions file to silence them:
+
+```bash
+LSAN_OPTIONS="suppressions=$(pwd)/lsan.supp" FUZZ=deserialize_invoice ./bitcoinfuzz
+LSAN_OPTIONS="suppressions=$(pwd)/lsan.supp" FUZZ=deserialize_offer ./bitcoinfuzz
+```
+
+This suppressions file was only validated on Ubuntu and might not work depending
+on your setup. You can write your own file or disable the leak detection
+globally.

--- a/modules/embit/README.md
+++ b/modules/embit/README.md
@@ -1,0 +1,21 @@
+# embit module
+
+Upstream: [embit](https://github.com/diybitcoinhardware/embit)
+
+## Dependencies
+
+To run the fuzzer with the `embit` module, you need to install the `embit`
+library:
+
+```bash
+cd modules/embit
+pip install -r ./requirements.txt
+```
+
+## Build
+
+```bash
+cd modules/embit
+make
+export CXXFLAGS="$CXXFLAGS -DEMBIT"
+```

--- a/modules/gocoin/README.md
+++ b/modules/gocoin/README.md
@@ -1,0 +1,19 @@
+# gocoin module
+
+Upstream: [gocoin](https://github.com/piotrnar/gocoin)
+
+[gocoin](https://github.com/piotrnar/gocoin) is a full Bitcoin node
+implementation written in Go.
+
+## Build
+
+```bash
+cd modules/gocoin
+make
+export CXXFLAGS="$CXXFLAGS -DGOCOIN"
+```
+
+## Notes
+
+gocoin cannot be used together with btcd in the same build due to cgo symbol
+conflicts. Both embed the Go runtime.

--- a/modules/ldk/README.md
+++ b/modules/ldk/README.md
@@ -1,0 +1,11 @@
+# LDK module
+
+Upstream: [LDK](https://github.com/lightningdevkit/rust-lightning)
+
+## Build
+
+```bash
+cd modules/ldk
+make
+export CXXFLAGS="$CXXFLAGS -DLDK"
+```

--- a/modules/libbitcoinsystem/README.md
+++ b/modules/libbitcoinsystem/README.md
@@ -1,0 +1,22 @@
+# libbitcoin-system module
+
+Upstream: [libbitcoin-system](https://github.com/libbitcoin/libbitcoin-system)
+
+## Dependencies
+
+Requires Boost (>= 1.86), CMake (>= 3.30), and binutils (`objcopy`).
+
+On Debian/Ubuntu:
+
+```bash
+apt-get install libboost-all-dev cmake binutils
+```
+
+## Build
+
+```bash
+git submodule update --init --recursive external/libbitcoin-system external/secp256k1
+cd modules/libbitcoinsystem
+make
+export CXXFLAGS="$CXXFLAGS -DLIBBITCOIN_SYSTEM"
+```

--- a/modules/libbitcoinsystem/module.cpp
+++ b/modules/libbitcoinsystem/module.cpp
@@ -90,16 +90,19 @@ LibbitcoinSystem::transaction_eval(std::span<const uint8_t> buffer) const {
     return "0";
   }
 
+  // Check for double spend, CVE-2018-17144. Libbitcoin checks for double spend
+  // during block validation at block::is_internal_double_spend() called from
+  // block::check()
   chain::points points;
   const auto inputs_ptr = tx.inputs_ptr();
   for (const auto &input_ptr : *inputs_ptr) {
     points.push_back(input_ptr->point());
   }
-  // Check for double spend, CVE-2018-17144
   if (!is_distinct(points))
     return "0";
 
-  // Check for spend overflow, CVE-2010-5139.
+  // Check for spend overflow, CVE-2010-5139. Libbitcoin checks for
+  // overspending at block::is_overspent() called from block::accept()
   const auto outputs_ptr = tx.outputs_ptr();
   for (const auto &output : *outputs_ptr) {
     const uint64_t value = output->value();
@@ -264,7 +267,7 @@ LibbitcoinSystem::script_eval(const std::vector<uint8_t> &input_data,
     return false;
   }
 
-  // Uses an 0P_1 scripPubkey to alway push truthy, so that script_eval tests
+  // Uses an 0P_1 scripPubkey to always push truthy, so that script_eval tests
   // whether script executes without error, as oposed to whether it leaves
   // a truth value on stack, which is tested by ggipt target.
   // Concrete divergence: scriptSig=OP_0 → bitcoin core false,

--- a/modules/libwallycore/README.md
+++ b/modules/libwallycore/README.md
@@ -1,0 +1,12 @@
+# libwally-core module
+
+Upstream: [libwally-core](https://github.com/ElementsProject/libwally-core)
+
+## Build
+
+```bash
+git submodule update --init --recursive external/libwally-core
+cd modules/libwallycore
+make
+export CXXFLAGS="$CXXFLAGS -DLIBWALLY_CORE"
+```

--- a/modules/lightningkmp/README.md
+++ b/modules/lightningkmp/README.md
@@ -1,0 +1,11 @@
+# lightning-kmp module
+
+Upstream: [lightning-kmp](https://github.com/ACINQ/lightning-kmp)
+
+## Build
+
+```bash
+cd modules/lightningkmp
+make
+export CXXFLAGS="$CXXFLAGS -DLIGHTNING_KMP"
+```

--- a/modules/lnd/README.md
+++ b/modules/lnd/README.md
@@ -1,0 +1,11 @@
+# LND module
+
+Upstream: [LND](https://github.com/lightningnetwork/lnd)
+
+## Build
+
+```bash
+cd modules/lnd
+make
+export CXXFLAGS="$CXXFLAGS -DLND"
+```

--- a/modules/nbitcoin/README.md
+++ b/modules/nbitcoin/README.md
@@ -1,0 +1,11 @@
+# NBitcoin module
+
+Upstream: [NBitcoin](https://github.com/MetacoSA/NBitcoin)
+
+## Build
+
+```bash
+cd modules/nbitcoin
+make
+export CXXFLAGS="$CXXFLAGS -DNBITCOIN"
+```

--- a/modules/nbitcoinsecp256k1/README.md
+++ b/modules/nbitcoinsecp256k1/README.md
@@ -1,0 +1,11 @@
+# NBitcoin-Secp256k1 module
+
+Upstream: [NBitcoin-Secp256k1](https://github.com/MetacoSA/NBitcoin/tree/master/NBitcoin.Secp256k1)
+
+## Build
+
+```bash
+cd modules/nbitcoinsecp256k1
+make
+export CXXFLAGS="$CXXFLAGS -DNBITCOIN_SECP256K1"
+```

--- a/modules/nlightning/README.md
+++ b/modules/nlightning/README.md
@@ -1,0 +1,11 @@
+# NLightning module
+
+Upstream: [NLightning](https://github.com/ipms-io/nlightning)
+
+## Build
+
+```bash
+cd modules/nlightning
+make
+export CXXFLAGS="$CXXFLAGS -DNLIGHTNING"
+```

--- a/modules/pybitcoinkernel/README.md
+++ b/modules/pybitcoinkernel/README.md
@@ -1,0 +1,21 @@
+# py-bitcoinkernel module
+
+Upstream: [py-bitcoinkernel](https://github.com/stickies-v/py-bitcoinkernel)
+
+## Dependencies
+
+To run the fuzzer with the `py-bitcoinkernel` module, you need to install the
+`py-bitcoinkernel` library:
+
+```bash
+cd modules/pybitcoinkernel
+pip install -r ./requirements.txt
+```
+
+## Build
+
+```bash
+cd modules/pybitcoinkernel
+make
+export CXXFLAGS="$CXXFLAGS -DPYBITCOINKERNEL"
+```

--- a/modules/pycoin/README.md
+++ b/modules/pycoin/README.md
@@ -1,0 +1,21 @@
+# pycoin module
+
+Upstream: [pycoin](https://github.com/richardkiss/pycoin)
+
+## Dependencies
+
+To run the fuzzer with the `pycoin` module, you need to install the `pycoin`
+library:
+
+```bash
+cd modules/pycoin
+pip install -r ./requirements.txt
+```
+
+## Build
+
+```bash
+cd modules/pycoin
+make
+export CXXFLAGS="$CXXFLAGS -DPYCOIN"
+```

--- a/modules/rustbitcoin/README.md
+++ b/modules/rustbitcoin/README.md
@@ -1,0 +1,11 @@
+# rust-bitcoin module
+
+Upstream: [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin)
+
+## Build
+
+```bash
+cd modules/rustbitcoin
+make
+export CXXFLAGS="$CXXFLAGS -DRUST_BITCOIN"
+```

--- a/modules/rustbitcoinkernel/README.md
+++ b/modules/rustbitcoinkernel/README.md
@@ -1,0 +1,11 @@
+# rust-bitcoinkernel module
+
+Upstream: [rust-bitcoinkernel](https://github.com/sedited/rust-bitcoinkernel)
+
+## Build
+
+```bash
+cd modules/rustbitcoinkernel
+make
+export CXXFLAGS="$CXXFLAGS -DRUSTBITCOINKERNEL"
+```

--- a/modules/rustk256/README.md
+++ b/modules/rustk256/README.md
@@ -1,0 +1,11 @@
+# K256 module
+
+Upstream: [K256](https://github.com/RustCrypto/elliptic-curves/tree/master/k256)
+
+## Build
+
+```bash
+cd modules/rustk256
+make
+export CXXFLAGS="$CXXFLAGS -DRUST_K256"
+```

--- a/modules/rustminiscript/README.md
+++ b/modules/rustminiscript/README.md
@@ -1,0 +1,11 @@
+# rust-miniscript module
+
+Upstream: [rust-miniscript](https://github.com/rust-bitcoin/rust-miniscript)
+
+## Build
+
+```bash
+cd modules/rustminiscript
+make
+export CXXFLAGS="$CXXFLAGS -DRUST_MINISCRIPT"
+```

--- a/modules/rustpsbt/README.md
+++ b/modules/rustpsbt/README.md
@@ -1,0 +1,11 @@
+# rust-psbt module
+
+Upstream: [rust-psbt](https://github.com/rust-bitcoin/rust-psbt)
+
+## Build
+
+```bash
+cd modules/rustpsbt
+make
+export CXXFLAGS="$CXXFLAGS -DRUST_PSBT"
+```

--- a/modules/rustreexo/README.md
+++ b/modules/rustreexo/README.md
@@ -1,0 +1,11 @@
+# Rustreexo module
+
+Upstream: [Rustreexo](https://github.com/mit-dci/rustreexo)
+
+## Build
+
+```bash
+cd modules/rustreexo
+make
+export CXXFLAGS="$CXXFLAGS -DRUSTREEXO"
+```

--- a/modules/secp256k1/README.md
+++ b/modules/secp256k1/README.md
@@ -1,0 +1,12 @@
+# Libsecp256k1 module
+
+Upstream: [Libsecp256k1](https://github.com/bitcoin-core/secp256k1)
+
+## Build
+
+```bash
+git submodule update --init --recursive external/secp256k1
+cd modules/secp256k1
+make
+export CXXFLAGS="$CXXFLAGS -DSECP256K1"
+```

--- a/modules/tinyminiscript/README.md
+++ b/modules/tinyminiscript/README.md
@@ -1,0 +1,11 @@
+# tinyminiscript module
+
+Upstream: [tinyminiscript](https://github.com/unldenis/tinyminiscript)
+
+## Build
+
+```bash
+cd modules/tinyminiscript
+make
+export CXXFLAGS="$CXXFLAGS -DTINY_MINISCRIPT"
+```

--- a/modules/utreexo/README.md
+++ b/modules/utreexo/README.md
@@ -1,0 +1,11 @@
+# Utreexo module
+
+Upstream: [Utreexo](https://github.com/utreexo/utreexo)
+
+## Build
+
+```bash
+cd modules/utreexo
+make
+export CXXFLAGS="$CXXFLAGS -DUTREEXO"
+```


### PR DESCRIPTION
- [a6bd14b](https://github.com/bitcoinfuzz/bitcoinfuzz/pull/579/commits/a6bd14b83defe876ac9ee5139bf43ebd64196bed) change comments to make it more explicit that some checks added in `Libbitcoinsystem::transaction_eval()` have been manually added because libbitcoin checks them during block validation instead of transaction validation.
- [60829b8](https://github.com/bitcoinfuzz/bitcoinfuzz/pull/579/commits/60829b81c5b6f2df5a13b913144bfb83caddc18f) declutter root README by moving module-specific instructions to a new README for each module.

