### PR TITLE
Suppress known false-positive leaks regarding nbitcoin and bitcoin-s.

### DIFF
--- a/lsan.supp
+++ b/lsan.supp
@@ -44,3 +44,5 @@ leak:Unsafe_AllocateMemory0
 # JFR (Java Flight Recorder) instruments classes during loading; the transformed
 # bytecode buffer is owned by the JVM class subsystem — not a real leak.
 leak:JfrEventClassTransformer::
+# .NET NativeAOT process-lifetime WaitSubsystem monitor
+leak:S_P_CoreLib_System_Threading_WaitSubsystem___cctor

--- a/lsan.supp
+++ b/lsan.supp
@@ -46,3 +46,6 @@ leak:Unsafe_AllocateMemory0
 leak:JfrEventClassTransformer::
 # .NET NativeAOT process-lifetime WaitSubsystem monitor
 leak:S_P_CoreLib_System_Threading_WaitSubsystem___cctor
+# BitcoinS secp256k1-zkp global verification/signing context, initialized once
+# and retained for the lifetime of the JVM process.
+leak:secp256k1_context_create

--- a/modules/bitcoins/README.md
+++ b/modules/bitcoins/README.md
@@ -9,3 +9,13 @@ cd modules/bitcoins
 make
 export CXXFLAGS="$CXXFLAGS -DBITCOINS"
 ```
+
+## Notes
+
+When fuzzing with BitcoinS, JVM initialization can cause LSan to report
+process-lifetime allocations as leaks. If this happens, use the provided
+suppression file:
+
+```bash
+LSAN_OPTIONS="suppressions=$(pwd)/lsan.supp" MODULES="BITCOINS" FUZZ=<target> ./bitcoinfuzz
+```

--- a/modules/nbitcoin/README.md
+++ b/modules/nbitcoin/README.md
@@ -9,3 +9,13 @@ cd modules/nbitcoin
 make
 export CXXFLAGS="$CXXFLAGS -DNBITCOIN"
 ```
+
+## Notes
+
+When fuzzing with NBitcoin, .NET NativeAOT runtime initialization can cause
+LSan to report a small false-positive leak from CoreLib's internal
+WaitSubsystem. Use the provided suppressions file if this happens:
+
+```bash
+LSAN_OPTIONS="suppressions=$(pwd)/lsan.supp" MODULES="NBITCOIN" FUZZ=<target> ./bitcoinfuzz
+```


### PR DESCRIPTION
Adds documentation and lsan rules for false-positive leaks mentioned on [#612](https://github.com/bitcoinfuzz/bitcoinfuzz/issues/612#issuecomment-5102252160)