### PR TITLE
Return error on failed psbt parse

### DIFF
--- a/driver.cpp
+++ b/driver.cpp
@@ -233,8 +233,8 @@ void Driver::PSBTParseTarget(std::span<const uint8_t> buffer) const {
     // Treat malformed parses consistently across modules. For this target, an
     // empty result or a zero-input/zero-output transaction is not a meaningful
     // successful parse and should not participate in differential comparison.
-    if (res->empty() || res->find("in=0") != std::string::npos ||
-        res->find("out=0") != std::string::npos)
+    if (res->empty() || res->find("inputs=0") != std::string::npos ||
+        res->find("outputs=0") != std::string::npos)
       continue;
 
     LogResponse(module.first, *res);

--- a/modules/bitcoin/module.cpp
+++ b/modules/bitcoin/module.cpp
@@ -561,7 +561,7 @@ Bitcoin::psbt_parse(std::span<const uint8_t> buffer) const {
   util::Result<PartiallySignedTransaction> psbt_result{
       DecodeRawPSBT(std::as_bytes(buffer))};
   if (!psbt_result) {
-    return std::string{};
+    return std::string{"INVALID"};
   }
   const PartiallySignedTransaction psbt{*psbt_result};
 
@@ -658,7 +658,7 @@ Bitcoin::psbt_parse(std::span<const uint8_t> buffer) const {
     }
 
   } catch (const std::exception &e) {
-    return std::string{};
+    return std::string{"INVALID"};
   }
 
   return result;

--- a/modules/bitcoin/module.cpp
+++ b/modules/bitcoin/module.cpp
@@ -558,20 +558,20 @@ Bitcoin::psbt_parse(std::span<const uint8_t> buffer) const {
     return std::nullopt;
   }
 
-  util::Result<PartiallySignedTransaction> psbt_res{
+  util::Result<PartiallySignedTransaction> psbt_result{
       DecodeRawPSBT(std::as_bytes(buffer))};
-  if (!psbt_res) {
+  if (!psbt_result) {
     return std::string{};
   }
-  const PartiallySignedTransaction psbt{*psbt_res};
+  const PartiallySignedTransaction psbt{*psbt_result};
 
   std::string result;
 
   try {
     // Extract high-level transaction properties (matching rust-bitcoin format)
     // result += "v=" + std::to_string(tx.version) + ";";
-    const std::optional<uint32_t> lt{DeterminePSBTLockTime(psbt)};
-    if (!lt.has_value()) {
+    const std::optional<uint32_t> lock_time{DeterminePSBTLockTime(psbt)};
+    if (!lock_time.has_value()) {
       // Conflicting per-input lock time requirements (BIP-370). This is a
       // well-defined "reject" outcome, not a generic parse failure, so use a
       // non-empty sentinel (the driver's PSBTParseTarget skips empty results
@@ -579,24 +579,24 @@ Bitcoin::psbt_parse(std::span<const uint8_t> buffer) const {
       // rejecting it, mirroring the other PSBTv2-aware modules.
       return std::string{"CONFLICTING_LOCKTIME"};
     }
-    result += "lt=" + std::to_string(*lt) + ";";
-    result += "in=" + std::to_string(psbt.inputs.size()) + ";";
-    result += "out=" + std::to_string(psbt.outputs.size()) + ";";
+    result += "lock_time=" + std::to_string(*lock_time) + ";";
+    result += "inputs=" + std::to_string(psbt.inputs.size()) + ";";
+    result += "outputs=" + std::to_string(psbt.outputs.size()) + ";";
 
     // Extract input information (matching rust-bitcoin format exactly)
     for (size_t i = 0; i < psbt.inputs.size(); i++) {
       const PSBTInput &psbt_input{psbt.inputs.at(i)};
 
       // Previous output reference in format "txid:vout"
-      result += "in" + std::to_string(i) +
-                "prev=" + psbt_input.prev_txid.ToString() + ":" +
+      result += "input" + std::to_string(i) +
+                "previous_output=" + psbt_input.prev_txid.ToString() + ":" +
                 std::to_string(psbt_input.prev_out) + ";";
 
       // Sequence number
-      const auto seq{psbt_input.sequence.has_value()
-                         ? std::to_string(psbt_input.sequence.value())
-                         : ""};
-      result += "in" + std::to_string(i) + "seq=" + seq + ";";
+      const auto sequence{psbt_input.sequence.has_value()
+                              ? std::to_string(psbt_input.sequence.value())
+                              : ""};
+      result += "input" + std::to_string(i) + "sequence=" + sequence + ";";
 
       // UTXO availability (check both witness and non-witness UTXO)
       bool has_utxo = false;
@@ -604,33 +604,33 @@ Bitcoin::psbt_parse(std::span<const uint8_t> buffer) const {
         has_utxo = true;
       }
       if (has_utxo) {
-        result += "in" + std::to_string(i) + "utxo=1;";
+        result += "input" + std::to_string(i) + "utxo=1;";
       }
 
       // Partial signatures count
-      result += "in" + std::to_string(i) +
-                "sigs=" + std::to_string(psbt_input.partial_sigs.size()) + ";";
+      result += "input" + std::to_string(i) + "partial_signatures=" +
+                std::to_string(psbt_input.partial_sigs.size()) + ";";
 
       // Redeem/witness scripts as hex
-      result += "in" + std::to_string(i) +
-                "rs=" + HexStr(psbt_input.redeem_script) + ";";
-      result += "in" + std::to_string(i) +
-                "ws=" + HexStr(psbt_input.witness_script) + ";";
+      result += "input" + std::to_string(i) +
+                "redeem_script=" + HexStr(psbt_input.redeem_script) + ";";
+      result += "input" + std::to_string(i) +
+                "witness_script=" + HexStr(psbt_input.witness_script) + ";";
 
       // Sighash type (0 if unset)
-      result += "in" + std::to_string(i) + "sh=" +
+      result += "input" + std::to_string(i) + "sighash_type=" +
                 std::to_string(static_cast<uint32_t>(
                     psbt_input.sighash_type.value_or(0))) +
                 ";";
 
       // BIP32 derivation count
-      result += "in" + std::to_string(i) +
+      result += "input" + std::to_string(i) +
                 "bip32=" + std::to_string(psbt_input.hd_keypaths.size()) + ";";
 
       // Finalized status
       if (!psbt_input.final_script_sig.empty() ||
           !psbt_input.final_script_witness.IsNull()) {
-        result += "in" + std::to_string(i) + "fin=1;";
+        result += "input" + std::to_string(i) + "finalized=1;";
       }
     }
 
@@ -639,21 +639,21 @@ Bitcoin::psbt_parse(std::span<const uint8_t> buffer) const {
       const PSBTOutput &psbt_output{psbt.outputs.at(i)};
 
       // Output value (cast to int64_t to match rust-bitcoin's i64 cast)
-      result += "out" + std::to_string(i) + "val=" +
+      result += "output" + std::to_string(i) + "val=" +
                 std::to_string(static_cast<int64_t>(psbt_output.amount)) + ";";
 
       // Output script as hex string
-      result += "out" + std::to_string(i) +
+      result += "output" + std::to_string(i) +
                 "script=" + HexStr(psbt_output.script) + ";";
 
       // Redeem/witness scripts as hex
-      result += "out" + std::to_string(i) +
-                "rs=" + HexStr(psbt_output.redeem_script) + ";";
-      result += "out" + std::to_string(i) +
-                "ws=" + HexStr(psbt_output.witness_script) + ";";
+      result += "output" + std::to_string(i) +
+                "redeem_script=" + HexStr(psbt_output.redeem_script) + ";";
+      result += "output" + std::to_string(i) +
+                "witness_script=" + HexStr(psbt_output.witness_script) + ";";
 
       // BIP32 derivation count
-      result += "out" + std::to_string(i) +
+      result += "output" + std::to_string(i) +
                 "bip32=" + std::to_string(psbt_output.hd_keypaths.size()) + ";";
     }
 

--- a/modules/bitcoins/BitcoinSWrapper.java
+++ b/modules/bitcoins/BitcoinSWrapper.java
@@ -82,33 +82,37 @@ public class BitcoinSWrapper {
       Transaction tx = psbt.transaction();
 
       StringBuilder sb = new StringBuilder();
-      sb.append("lt=").append(tx.lockTime().toLong()).append(";");
-      sb.append("in=").append(tx.inputs().size()).append(";");
-      sb.append("out=").append(tx.outputs().size()).append(";");
+      sb.append("lock_time=").append(tx.lockTime().toLong()).append(";");
+      sb.append("inputs=").append(tx.inputs().size()).append(";");
+      sb.append("outputs=").append(tx.outputs().size()).append(";");
 
       scala.collection.immutable.Seq<?> inputs = tx.inputs();
       for (int i = 0; i < inputs.size(); i++) {
         TransactionInput txIn = (TransactionInput) inputs.apply(i);
         String prevHash = txIn.previousOutput().txIdBE().hex();
         long vout = txIn.previousOutput().vout().toLong();
-        sb.append("in")
+        sb.append("input")
             .append(i)
-            .append("prev=")
+            .append("previous_output=")
             .append(prevHash)
             .append(":")
             .append(vout)
             .append(";");
-        sb.append("in").append(i).append("seq=").append(txIn.sequence().toLong()).append(";");
+        sb.append("input")
+            .append(i)
+            .append("sequence=")
+            .append(txIn.sequence().toLong())
+            .append(";");
 
         InputPSBTMap inp = (InputPSBTMap) psbt.inputMaps().apply(i);
         boolean hasUtxo =
             inp.nonWitnessOrUnknownUTXOOpt().isDefined() || inp.witnessUTXOOpt().isDefined();
         if (hasUtxo) {
-          sb.append("in").append(i).append("utxo=1;");
+          sb.append("input").append(i).append("utxo=1;");
         }
-        sb.append("in")
+        sb.append("input")
             .append(i)
-            .append("sigs=")
+            .append("partial_signatures=")
             .append(inp.partialSignatures().size())
             .append(";");
 
@@ -119,7 +123,7 @@ public class BitcoinSWrapper {
             inp.redeemScriptOpt().isDefined()
                 ? inp.redeemScriptOpt().get().redeemScript().asmHex()
                 : "";
-        sb.append("in").append(i).append("rs=").append(redeemScriptHex).append(";");
+        sb.append("input").append(i).append("redeem_script=").append(redeemScriptHex).append(";");
 
         // witnessScript() is typed as RawScriptPubKey, an interface that
         // doesn't itself expose asmHex() to Java; cast to Script (every
@@ -128,22 +132,22 @@ public class BitcoinSWrapper {
             inp.witnessScriptOpt().isDefined()
                 ? ((Script) inp.witnessScriptOpt().get().witnessScript()).asmHex()
                 : "";
-        sb.append("in").append(i).append("ws=").append(witnessScriptHex).append(";");
+        sb.append("input").append(i).append("witness_script=").append(witnessScriptHex).append(";");
 
         // raw PSBT_IN_SIGHASH_TYPE value, or 0 if unset. HashType.num() is a
         // signed Java int holding the raw 4 bytes, so any value with the top
         // bit set (e.g. 0xfe8f263f) would render negative, while every other
         // module formats it unsigned (Bitcoin Core casts to uint32_t, btcd to
         // uint32, rust-psbt uses to_u32). Print it unsigned to match.
-        int sighash =
+        int sighashType =
             inp.sigHashTypeOpt().isDefined() ? inp.sigHashTypeOpt().get().hashType().num() : 0;
-        sb.append("in")
+        sb.append("input")
             .append(i)
-            .append("sh=")
-            .append(Integer.toUnsignedString(sighash))
+            .append("sighash_type=")
+            .append(Integer.toUnsignedString(sighashType))
             .append(";");
 
-        sb.append("in")
+        sb.append("input")
             .append(i)
             .append("bip32=")
             .append(inp.BIP32DerivationPaths().length())
@@ -164,19 +168,19 @@ public class BitcoinSWrapper {
             inp.finalizedScriptWitnessOpt().isDefined()
                 && !inp.finalizedScriptWitnessOpt().get().scriptWitness().stack().isEmpty();
         if (finalizedScriptSig || finalizedScriptWitness) {
-          sb.append("in").append(i).append("fin=1;");
+          sb.append("input").append(i).append("finalized=1;");
         }
       }
 
       scala.collection.immutable.Seq<?> outputs = tx.outputs();
       for (int i = 0; i < outputs.size(); i++) {
         TransactionOutput txOut = (TransactionOutput) outputs.apply(i);
-        sb.append("out")
+        sb.append("output")
             .append(i)
             .append("val=")
             .append(txOut.value().satoshis().toLong())
             .append(";");
-        sb.append("out")
+        sb.append("output")
             .append(i)
             .append("script=")
             .append(txOut.scriptPubKey().asmHex())
@@ -189,15 +193,23 @@ public class BitcoinSWrapper {
               out.redeemScriptOpt().isDefined()
                   ? out.redeemScriptOpt().get().redeemScript().asmHex()
                   : "";
-          sb.append("out").append(i).append("rs=").append(outRedeemScriptHex).append(";");
+          sb.append("output")
+              .append(i)
+              .append("redeem_script=")
+              .append(outRedeemScriptHex)
+              .append(";");
 
           String outWitnessScriptHex =
               out.witnessScriptOpt().isDefined()
                   ? out.witnessScriptOpt().get().witnessScript().asmHex()
                   : "";
-          sb.append("out").append(i).append("ws=").append(outWitnessScriptHex).append(";");
+          sb.append("output")
+              .append(i)
+              .append("witness_script=")
+              .append(outWitnessScriptHex)
+              .append(";");
 
-          sb.append("out")
+          sb.append("output")
               .append(i)
               .append("bip32=")
               .append(out.BIP32DerivationPaths().length())

--- a/modules/bitcoins/BitcoinSWrapper.java
+++ b/modules/bitcoins/BitcoinSWrapper.java
@@ -220,7 +220,7 @@ public class BitcoinSWrapper {
       return sb.toString();
 
     } catch (Exception e) {
-      return "";
+      return "INVALID";
     }
   }
 }

--- a/modules/btcd/btcd_wrapper/wrapper.go
+++ b/modules/btcd/btcd_wrapper/wrapper.go
@@ -260,7 +260,7 @@ func BTCDTransactionEval(data C.ByteArray) *C.char {
 // finalized. Bitcoin Core stores its final witness as a plain CScriptWitness
 // whose IsNull() is just stack.empty(), so it cannot distinguish an absent key
 // from one present with a zero-item stack; matching on item count keeps the
-// `fin` flag comparable across modules. An empty witness finalizes nothing.
+// `finalized` flag comparable across modules. An empty witness finalizes nothing.
 func finalWitnessHasItems(raw []byte) bool {
 	if len(raw) == 0 {
 		return false
@@ -295,43 +295,43 @@ func BTCDParsePSBT(data C.ByteArray) *C.char {
 
 	var result strings.Builder // format psbt similar to rust_bitcoin
 
-	//result.WriteString(fmt.Sprintf("v=%d;", packet.UnsignedTx.Version))      // add Tx ver
-	result.WriteString(fmt.Sprintf("lt=%d;", packet.UnsignedTx.LockTime))    // add locktime
-	result.WriteString(fmt.Sprintf("in=%d;", len(packet.UnsignedTx.TxIn)))   // add ip count
-	result.WriteString(fmt.Sprintf("out=%d;", len(packet.UnsignedTx.TxOut))) // add op count
+	//result.WriteString(fmt.Sprintf("v=%d;", packet.UnsignedTx.Version))        // add Tx ver
+	result.WriteString(fmt.Sprintf("lock_time=%d;", packet.UnsignedTx.LockTime)) // add locktime
+	result.WriteString(fmt.Sprintf("inputs=%d;", len(packet.UnsignedTx.TxIn)))   // add ip count
+	result.WriteString(fmt.Sprintf("outputs=%d;", len(packet.UnsignedTx.TxOut))) // add op count
 
 	// processing ip
 	for i, txIn := range packet.UnsignedTx.TxIn {
 		if i < len(packet.Inputs) {
 			// prev op (txid:vout)
-			result.WriteString(fmt.Sprintf("in%dprev=%s:%d;",
+			result.WriteString(fmt.Sprintf("input%dprevious_output=%s:%d;",
 				i, txIn.PreviousOutPoint.Hash.String(), txIn.PreviousOutPoint.Index))
 
 			// seq number
-			result.WriteString(fmt.Sprintf("in%dseq=%d;", i, txIn.Sequence))
+			result.WriteString(fmt.Sprintf("input%dsequence=%d;", i, txIn.Sequence))
 
 			// check UTXO info
 			if packet.Inputs[i].WitnessUtxo != nil || packet.Inputs[i].NonWitnessUtxo != nil {
-				result.WriteString(fmt.Sprintf("in%dutxo=1;", i))
+				result.WriteString(fmt.Sprintf("input%dutxo=1;", i))
 			}
 
 			// count partial sig
-			sigCount := len(packet.Inputs[i].PartialSigs)
-			result.WriteString(fmt.Sprintf("in%dsigs=%d;", i, sigCount))
+			partialSignatureCount := len(packet.Inputs[i].PartialSigs)
+			result.WriteString(fmt.Sprintf("input%dpartial_signatures=%d;", i, partialSignatureCount))
 
 			// redeem/witness scripts as hex (empty if absent)
-			result.WriteString(fmt.Sprintf("in%drs=%x;", i, packet.Inputs[i].RedeemScript))
-			result.WriteString(fmt.Sprintf("in%dws=%x;", i, packet.Inputs[i].WitnessScript))
+			result.WriteString(fmt.Sprintf("input%dredeem_script=%x;", i, packet.Inputs[i].RedeemScript))
+			result.WriteString(fmt.Sprintf("input%dwitness_script=%x;", i, packet.Inputs[i].WitnessScript))
 
 			// sighash type (0 if unset)
-			result.WriteString(fmt.Sprintf("in%dsh=%d;", i, uint32(packet.Inputs[i].SighashType)))
+			result.WriteString(fmt.Sprintf("input%dsighash_type=%d;", i, uint32(packet.Inputs[i].SighashType)))
 
 			// BIP32 derivation count
-			result.WriteString(fmt.Sprintf("in%dbip32=%d;", i, len(packet.Inputs[i].Bip32Derivation)))
+			result.WriteString(fmt.Sprintf("input%dbip32=%d;", i, len(packet.Inputs[i].Bip32Derivation)))
 
 			// finalized status
 			if len(packet.Inputs[i].FinalScriptSig) > 0 || finalWitnessHasItems(packet.Inputs[i].FinalScriptWitness) {
-				result.WriteString(fmt.Sprintf("in%dfin=1;", i))
+				result.WriteString(fmt.Sprintf("input%dfinalized=1;", i))
 			}
 		}
 	}
@@ -339,16 +339,16 @@ func BTCDParsePSBT(data C.ByteArray) *C.char {
 	// processing op
 	for i, txOut := range packet.UnsignedTx.TxOut {
 		if i < len(packet.Outputs) {
-			result.WriteString(fmt.Sprintf("out%dval=%d;", i, txOut.Value))
+			result.WriteString(fmt.Sprintf("output%dval=%d;", i, txOut.Value))
 			scriptHex := fmt.Sprintf("%x", txOut.PkScript) // script pubkey as hex
-			result.WriteString(fmt.Sprintf("out%dscript=%s;", i, scriptHex))
+			result.WriteString(fmt.Sprintf("output%dscript=%s;", i, scriptHex))
 
 			// redeem/witness scripts as hex (empty if absent)
-			result.WriteString(fmt.Sprintf("out%drs=%x;", i, packet.Outputs[i].RedeemScript))
-			result.WriteString(fmt.Sprintf("out%dws=%x;", i, packet.Outputs[i].WitnessScript))
+			result.WriteString(fmt.Sprintf("output%dredeem_script=%x;", i, packet.Outputs[i].RedeemScript))
+			result.WriteString(fmt.Sprintf("output%dwitness_script=%x;", i, packet.Outputs[i].WitnessScript))
 
 			// BIP32 derivation count
-			result.WriteString(fmt.Sprintf("out%dbip32=%d;", i, len(packet.Outputs[i].Bip32Derivation)))
+			result.WriteString(fmt.Sprintf("output%dbip32=%d;", i, len(packet.Outputs[i].Bip32Derivation)))
 		}
 	}
 

--- a/modules/btcd/btcd_wrapper/wrapper.go
+++ b/modules/btcd/btcd_wrapper/wrapper.go
@@ -279,20 +279,27 @@ func BTCDParsePSBT(data C.ByteArray) *C.char {
 	var packet *psbt.Packet
 	var err error
 
-	packet, err = psbt.NewFromRawBytes(bytes.NewBuffer(buffer), false)
+	reader := bytes.NewReader(buffer)
+	packet, err = psbt.NewFromRawBytes(reader, false)
 
 	if err != nil { // base64 if binary fails
 		str := string(buffer)
 		decodedBytes, decodeErr := base64.StdEncoding.DecodeString(str)
 		if decodeErr != nil {
-			return nil
+			return C.CString("INVALID")
 		}
-		packet, err = psbt.NewFromRawBytes(bytes.NewBuffer(decodedBytes), false)
+		reader = bytes.NewReader(decodedBytes)
+		packet, err = psbt.NewFromRawBytes(reader, false)
 		if err != nil {
-			return nil
+			return C.CString("INVALID")
 		}
 	}
 
+	// Bitcoin Core rejects extra data after a complete PSBT, while btcd stops
+	// after reading the expected maps. Require the entire input to be consumed.
+	if reader.Len() != 0 {
+		return C.CString("INVALID")
+	}
 	var result strings.Builder // format psbt similar to rust_bitcoin
 
 	//result.WriteString(fmt.Sprintf("v=%d;", packet.UnsignedTx.Version))        // add Tx ver

--- a/modules/embit/embit_lib.py
+++ b/modules/embit/embit_lib.py
@@ -35,14 +35,14 @@ def psbt_parse(data):
 
         tx = psbt_obj.tx
         # result.append(f"v={tx.version}")
-        result.append(f"lt={tx.locktime}")
-        result.append(f"in={len(tx.vin)}")
-        result.append(f"out={len(tx.vout)}")
+        result.append(f"lock_time={tx.locktime}")
+        result.append(f"inputs={len(tx.vin)}")
+        result.append(f"outputs={len(tx.vout)}")
 
         # ip details
         for i, vin in enumerate(tx.vin):
-            result.append(f"in{i}prev={vin.txid.hex()}:{vin.vout}")
-            result.append(f"in{i}seq={vin.sequence}")
+            result.append(f"input{i}previous_output={vin.txid.hex()}:{vin.vout}")
+            result.append(f"input{i}sequence={vin.sequence}")
 
             # check utxo
             psbt_input = psbt_obj.inputs[i]
@@ -53,37 +53,37 @@ def psbt_parse(data):
                 and psbt_input.non_witness_utxo is not None
             )
             if has_utxo:
-                result.append(f"in{i}utxo=1")
+                result.append(f"input{i}utxo=1")
 
-            # count sig
-            sig_count = (
+            # count partial signatures
+            partial_signature_count = (
                 len(psbt_input.partial_sigs)
                 if hasattr(psbt_input, "partial_sigs")
                 else 0
             )
-            result.append(f"in{i}sigs={sig_count}")
+            result.append(f"input{i}partial_signatures={partial_signature_count}")
 
             redeem_script_hex = (
                 psbt_input.redeem_script.data.hex()
                 if psbt_input.redeem_script is not None
                 else ""
             )
-            result.append(f"in{i}rs={redeem_script_hex}")
+            result.append(f"input{i}redeem_script={redeem_script_hex}")
 
             witness_script_hex = (
                 psbt_input.witness_script.data.hex()
                 if psbt_input.witness_script is not None
                 else ""
             )
-            result.append(f"in{i}ws={witness_script_hex}")
+            result.append(f"input{i}witness_script={witness_script_hex}")
 
             # raw PSBT_IN_SIGHASH_TYPE value, or 0 if unset
-            sighash = (
+            sighash_type = (
                 psbt_input.sighash_type if psbt_input.sighash_type is not None else 0
             )
-            result.append(f"in{i}sh={sighash}")
+            result.append(f"input{i}sighash_type={sighash_type}")
 
-            result.append(f"in{i}bip32={len(psbt_input.bip32_derivations)}")
+            result.append(f"input{i}bip32={len(psbt_input.bip32_derivations)}")
 
             # Report finalization on *non-empty* final scriptSig/scriptWitness
             # rather than mere presence. Bitcoin Core stores the final witness
@@ -97,11 +97,11 @@ def psbt_parse(data):
             if (final_scriptsig is not None and len(final_scriptsig.data) > 0) or (
                 final_scriptwitness is not None and len(final_scriptwitness.items) > 0
             ):
-                result.append(f"in{i}fin=1")
+                result.append(f"input{i}finalized=1")
 
         for i, vout in enumerate(tx.vout):
-            result.append(f"out{i}val={vout.value}")
-            result.append(f"out{i}script={vout.script_pubkey.data.hex()}")
+            result.append(f"output{i}val={vout.value}")
+            result.append(f"output{i}script={vout.script_pubkey.data.hex()}")
 
             psbt_output = psbt_obj.outputs[i]
 
@@ -110,16 +110,16 @@ def psbt_parse(data):
                 if psbt_output.redeem_script is not None
                 else ""
             )
-            result.append(f"out{i}rs={redeem_script_hex}")
+            result.append(f"output{i}redeem_script={redeem_script_hex}")
 
             witness_script_hex = (
                 psbt_output.witness_script.data.hex()
                 if psbt_output.witness_script is not None
                 else ""
             )
-            result.append(f"out{i}ws={witness_script_hex}")
+            result.append(f"output{i}witness_script={witness_script_hex}")
 
-            result.append(f"out{i}bip32={len(psbt_output.bip32_derivations)}")
+            result.append(f"output{i}bip32={len(psbt_output.bip32_derivations)}")
 
         return ";".join(result) + ";"
     except Exception as _:

--- a/modules/embit/embit_lib.py
+++ b/modules/embit/embit_lib.py
@@ -123,7 +123,7 @@ def psbt_parse(data):
 
         return ";".join(result) + ";"
     except Exception as _:
-        return None
+        return "INVALID"
 
 
 def bip32_master_keygen(data):

--- a/modules/libwallycore/module.cpp
+++ b/modules/libwallycore/module.cpp
@@ -328,9 +328,9 @@ LibwallyCore::psbt_parse(std::span<const uint8_t> buffer) const {
 
   if (psbt->tx) {
     // PSBTv0: the global unsigned tx carries locktime/inputs/outputs.
-    result << "lt=" << psbt->tx->locktime << ";";
-    result << "in=" << psbt->tx->num_inputs << ";";
-    result << "out=" << psbt->tx->num_outputs << ";";
+    result << "lock_time=" << psbt->tx->locktime << ";";
+    result << "inputs=" << psbt->tx->num_inputs << ";";
+    result << "outputs=" << psbt->tx->num_outputs << ";";
 
     for (size_t i = 0; i < psbt->tx->num_inputs; i++) {
       if (i < psbt->num_inputs) {
@@ -344,30 +344,32 @@ LibwallyCore::psbt_parse(std::span<const uint8_t> buffer) const {
         bool ok = hex_encode(txhash_reversed.data(), 32, txhash_hex.data(),
                              txhash_hex.size());
         assert(ok);
-        result << "in" << i << "prev=" << txhash_hex.data() << ":" << txin.index
-               << ";";
-        result << "in" << i << "seq=" << txin.sequence << ";";
+        result << "input" << i << "previous_output=" << txhash_hex.data() << ":"
+               << txin.index << ";";
+        result << "input" << i << "sequence=" << txin.sequence << ";";
 
         if (psbt_input.utxo || psbt_input.witness_utxo) {
-          result << "in" << i << "utxo=1" << ";";
+          result << "input" << i << "utxo=1" << ";";
         }
 
-        result << "in" << i << "sigs=" << psbt_input.signatures.num_items
+        result << "input" << i
+               << "partial_signatures=" << psbt_input.signatures.num_items
                << ";";
 
-        result << "in" << i << "rs="
+        result << "input" << i << "redeem_script="
                << GetMapFieldHex(psbt_input.psbt_fields,
                                  PSBT_IN_REDEEM_SCRIPT_KT)
                << ";";
-        result << "in" << i << "ws="
+        result << "input" << i << "witness_script="
                << GetMapFieldHex(psbt_input.psbt_fields,
                                  PSBT_IN_WITNESS_SCRIPT_KT)
                << ";";
-        result << "in" << i << "sh=" << psbt_input.sighash << ";";
-        result << "in" << i << "bip32=" << psbt_input.keypaths.num_items << ";";
+        result << "input" << i << "sighash_type=" << psbt_input.sighash << ";";
+        result << "input" << i << "bip32=" << psbt_input.keypaths.num_items
+               << ";";
 
         if (IsFinalized(psbt_input)) {
-          result << "in" << i << "fin=1;";
+          result << "input" << i << "finalized=1;";
         }
       }
     }
@@ -385,29 +387,29 @@ LibwallyCore::psbt_parse(std::span<const uint8_t> buffer) const {
       // convention (see modules/bitcoin/module.cpp), so a fuzzer-generated
       // amount near UINT64_MAX formats identically instead of one module
       // printing it as a huge unsigned value and the others as negative.
-      result << "out" << i << "val=" << static_cast<int64_t>(txout.satoshi)
+      result << "output" << i << "val=" << static_cast<int64_t>(txout.satoshi)
              << ";";
-      result << "out" << i << "script=" << script_hex.data() << ";";
+      result << "output" << i << "script=" << script_hex.data() << ";";
 
       if (i < psbt->num_outputs) {
         const wally_psbt_output &psbt_output = psbt->outputs[i];
-        result << "out" << i << "rs="
+        result << "output" << i << "redeem_script="
                << GetMapFieldHex(psbt_output.psbt_fields,
                                  PSBT_OUT_REDEEM_SCRIPT_KT)
                << ";";
-        result << "out" << i << "ws="
+        result << "output" << i << "witness_script="
                << GetMapFieldHex(psbt_output.psbt_fields,
                                  PSBT_OUT_WITNESS_SCRIPT_KT)
                << ";";
-        result << "out" << i << "bip32=" << psbt_output.keypaths.num_items
+        result << "output" << i << "bip32=" << psbt_output.keypaths.num_items
                << ";";
       }
     }
   } else {
     // PSBTv2 (BIP-370): tx data is per-input/output instead of a global
     // unsigned tx.
-    const std::optional<uint32_t> lt = DetermineV2LockTime(psbt);
-    if (!lt.has_value()) {
+    const std::optional<uint32_t> lock_time = DetermineV2LockTime(psbt);
+    if (!lock_time.has_value()) {
       wally_psbt_free(psbt);
       // Conflicting per-input lock time requirements (BIP-370). This is a
       // well-defined "reject" outcome, not a generic parse failure, so use a
@@ -417,9 +419,9 @@ LibwallyCore::psbt_parse(std::span<const uint8_t> buffer) const {
       return std::string{"CONFLICTING_LOCKTIME"};
     }
 
-    result << "lt=" << *lt << ";";
-    result << "in=" << psbt->num_inputs << ";";
-    result << "out=" << psbt->num_outputs << ";";
+    result << "lock_time=" << *lock_time << ";";
+    result << "inputs=" << psbt->num_inputs << ";";
+    result << "outputs=" << psbt->num_outputs << ";";
 
     for (size_t i = 0; i < psbt->num_inputs; i++) {
       const wally_psbt_input &psbt_input = psbt->inputs[i];
@@ -431,35 +433,37 @@ LibwallyCore::psbt_parse(std::span<const uint8_t> buffer) const {
       bool ok = hex_encode(txhash_reversed.data(), 32, txhash_hex.data(),
                            txhash_hex.size());
       assert(ok);
-      result << "in" << i << "prev=" << txhash_hex.data() << ":"
+      result << "input" << i << "previous_output=" << txhash_hex.data() << ":"
              << V2InputRawOutputIndex(buffer, i).value_or(psbt_input.index)
              << ";";
 
       if (psbt_input.sequence != WALLY_TX_SEQUENCE_FINAL ||
           V2InputHasExplicitSequence(buffer, i)) {
-        result << "in" << i << "seq=" << psbt_input.sequence << ";";
+        result << "input" << i << "sequence=" << psbt_input.sequence << ";";
       } else {
-        result << "in" << i << "seq=" << ";";
+        result << "input" << i << "sequence=" << ";";
       }
 
       if (psbt_input.utxo || psbt_input.witness_utxo) {
-        result << "in" << i << "utxo=1" << ";";
+        result << "input" << i << "utxo=1" << ";";
       }
 
-      result << "in" << i << "sigs=" << psbt_input.signatures.num_items << ";";
+      result << "input" << i
+             << "partial_signatures=" << psbt_input.signatures.num_items << ";";
 
-      result << "in" << i << "rs="
+      result << "input" << i << "redeem_script="
              << GetMapFieldHex(psbt_input.psbt_fields, PSBT_IN_REDEEM_SCRIPT_KT)
              << ";";
-      result << "in" << i << "ws="
+      result << "input" << i << "witness_script="
              << GetMapFieldHex(psbt_input.psbt_fields,
                                PSBT_IN_WITNESS_SCRIPT_KT)
              << ";";
-      result << "in" << i << "sh=" << psbt_input.sighash << ";";
-      result << "in" << i << "bip32=" << psbt_input.keypaths.num_items << ";";
+      result << "input" << i << "sighash_type=" << psbt_input.sighash << ";";
+      result << "input" << i << "bip32=" << psbt_input.keypaths.num_items
+             << ";";
 
       if (IsFinalized(psbt_input)) {
-        result << "in" << i << "fin=1;";
+        result << "input" << i << "finalized=1;";
       }
     }
 
@@ -471,21 +475,22 @@ LibwallyCore::psbt_parse(std::span<const uint8_t> buffer) const {
       bool ok = hex_encode(psbt_output.script, psbt_output.script_len,
                            script_hex.data(), script_hex.size());
       assert(ok);
-      result << "out" << i << "val="
+      result << "output" << i << "val="
              << static_cast<int64_t>(psbt_output.has_amount ? psbt_output.amount
                                                             : 0)
              << ";";
-      result << "out" << i << "script=" << script_hex.data() << ";";
+      result << "output" << i << "script=" << script_hex.data() << ";";
 
-      result << "out" << i << "rs="
+      result << "output" << i << "redeem_script="
              << GetMapFieldHex(psbt_output.psbt_fields,
                                PSBT_OUT_REDEEM_SCRIPT_KT)
              << ";";
-      result << "out" << i << "ws="
+      result << "output" << i << "witness_script="
              << GetMapFieldHex(psbt_output.psbt_fields,
                                PSBT_OUT_WITNESS_SCRIPT_KT)
              << ";";
-      result << "out" << i << "bip32=" << psbt_output.keypaths.num_items << ";";
+      result << "output" << i << "bip32=" << psbt_output.keypaths.num_items
+             << ";";
     }
   }
 

--- a/modules/libwallycore/module.cpp
+++ b/modules/libwallycore/module.cpp
@@ -321,7 +321,7 @@ LibwallyCore::psbt_parse(std::span<const uint8_t> buffer) const {
   int res = wally_psbt_from_bytes(buffer.data(), buffer.size(),
                                   WALLY_PSBT_PARSE_FLAG_STRICT, &psbt);
   if (res != WALLY_OK) {
-    return std::nullopt;
+    return std::string{"INVALID"};
   }
 
   std::ostringstream result;

--- a/modules/nbitcoin/NBitcoin/NBitcoinBridge.cs
+++ b/modules/nbitcoin/NBitcoin/NBitcoinBridge.cs
@@ -227,24 +227,24 @@ public static class Bridge
             }
 
             var result = new StringBuilder();
-            result.Append($"lt={tx.LockTime.Value};");
-            result.Append($"in={tx.Inputs.Count};");
-            result.Append($"out={tx.Outputs.Count};");
+            result.Append($"lock_time={tx.LockTime.Value};");
+            result.Append($"inputs={tx.Inputs.Count};");
+            result.Append($"outputs={tx.Outputs.Count};");
 
             for (int i = 0; i < tx.Inputs.Count; i++)
             {
                 var txIn = tx.Inputs[i];
 
-                result.Append($"in{i}prev={txIn.PrevOut.Hash}:{txIn.PrevOut.N};");
+                result.Append($"input{i}previous_output={txIn.PrevOut.Hash}:{txIn.PrevOut.N};");
 
                 uint seqValue = txIn.Sequence.Value;
                 if (!isV2 || seqValue != Sequence.Final.Value || V2InputHasExplicitSequence(psbtBytes, i))
                 {
-                    result.Append($"in{i}seq={seqValue};");
+                    result.Append($"input{i}sequence={seqValue};");
                 }
                 else
                 {
-                    result.Append($"in{i}seq=;");
+                    result.Append($"input{i}sequence=;");
                 }
 
                 if (i < psbt.Inputs.Count)
@@ -254,31 +254,31 @@ public static class Bridge
 
                     if (hasUtxo)
                     {
-                        result.Append($"in{i}utxo=1;");
+                        result.Append($"input{i}utxo=1;");
                     }
 
-                    int sigCount = psbtInput.PartialSigs?.Count ?? 0;
-                    result.Append($"in{i}sigs={sigCount};");
+                    int partialSignatureCount = psbtInput.PartialSigs?.Count ?? 0;
+                    result.Append($"input{i}partial_signatures={partialSignatureCount};");
 
-                    result.Append($"in{i}rs={psbtInput.RedeemScript?.ToHex() ?? ""};");
-                    result.Append($"in{i}ws={psbtInput.WitnessScript?.ToHex() ?? ""};");
+                    result.Append($"input{i}redeem_script={psbtInput.RedeemScript?.ToHex() ?? ""};");
+                    result.Append($"input{i}witness_script={psbtInput.WitnessScript?.ToHex() ?? ""};");
 
                     // Raw PSBT_IN_SIGHASH_TYPE byte value, or 0 if unset.
                     // SighashType/TaprootSighashType are mutually exclusive
                     // (legacy vs taproot input); both enums are backed by
                     // the same raw byte values as the wire format.
-                    uint sighash = 0;
+                    uint sighashType = 0;
                     if (psbtInput.SighashType.HasValue)
                     {
-                        sighash = (uint)psbtInput.SighashType.Value;
+                        sighashType = (uint)psbtInput.SighashType.Value;
                     }
                     else if (psbtInput.TaprootSighashType.HasValue)
                     {
-                        sighash = (uint)psbtInput.TaprootSighashType.Value;
+                        sighashType = (uint)psbtInput.TaprootSighashType.Value;
                     }
-                    result.Append($"in{i}sh={sighash};");
+                    result.Append($"input{i}sighash_type={sighashType};");
 
-                    result.Append($"in{i}bip32={psbtInput.HDKeyPaths.Count};");
+                    result.Append($"input{i}bip32={psbtInput.HDKeyPaths.Count};");
 
                     // Report finalization on a *non-empty* final
                     // scriptSig/scriptWitness rather than mere presence, which
@@ -294,7 +294,7 @@ public static class Bridge
                         || !WitScript.IsNullOrEmpty(psbtInput.FinalScriptWitness);
                     if (finalized)
                     {
-                        result.Append($"in{i}fin=1;");
+                        result.Append($"input{i}finalized=1;");
                     }
                 }
             }
@@ -304,17 +304,17 @@ public static class Bridge
                 var txOut = tx.Outputs[i];
 
                 long value = txOut.Value.Satoshi;
-                result.Append($"out{i}val={value};");
+                result.Append($"output{i}val={value};");
 
                 string scriptHex = txOut.ScriptPubKey.ToHex();
-                result.Append($"out{i}script={scriptHex};");
+                result.Append($"output{i}script={scriptHex};");
 
                 if (i < psbt.Outputs.Count)
                 {
                     var psbtOutput = psbt.Outputs[i];
-                    result.Append($"out{i}rs={psbtOutput.RedeemScript?.ToHex() ?? ""};");
-                    result.Append($"out{i}ws={psbtOutput.WitnessScript?.ToHex() ?? ""};");
-                    result.Append($"out{i}bip32={psbtOutput.HDKeyPaths.Count};");
+                    result.Append($"output{i}redeem_script={psbtOutput.RedeemScript?.ToHex() ?? ""};");
+                    result.Append($"output{i}witness_script={psbtOutput.WitnessScript?.ToHex() ?? ""};");
+                    result.Append($"output{i}bip32={psbtOutput.HDKeyPaths.Count};");
                 }
             }
 

--- a/modules/nbitcoin/NBitcoin/NBitcoinBridge.cs
+++ b/modules/nbitcoin/NBitcoin/NBitcoinBridge.cs
@@ -322,7 +322,7 @@ public static class Bridge
         }
         catch
         {
-            return Marshal.StringToHGlobalAnsi("");
+            return Marshal.StringToHGlobalAnsi("INVALID");
         }
     }
 

--- a/modules/rustpsbt/rust_psbt_lib/src/lib.rs
+++ b/modules/rustpsbt/rust_psbt_lib/src/lib.rs
@@ -339,6 +339,6 @@ pub unsafe extern "C" fn rust_psbt_psbt_parse(data: *const u8, len: usize) -> *m
         // entirely) rather than silently opted out, mirroring the other
         // PSBTv2-aware modules.
         Err(TryParseV2Error::ConflictingLockTime) => str_to_c_string("CONFLICTING_LOCKTIME"),
-        Err(TryParseV2Error::Invalid) => std::ptr::null_mut(),
+        Err(TryParseV2Error::Invalid) => str_to_c_string("INVALID"),
     }
 }

--- a/modules/rustpsbt/rust_psbt_lib/src/lib.rs
+++ b/modules/rustpsbt/rust_psbt_lib/src/lib.rs
@@ -33,11 +33,11 @@ struct InputSummary {
     // PSBTv2 (BIP-370 says it then defaults to the final sequence number).
     sequence: Option<u32>,
     has_utxo: bool,
-    sigs: usize,
+    partial_signatures: usize,
     redeem_script_hex: String,
     witness_script_hex: String,
     // Raw PSBT_IN_SIGHASH_TYPE byte value, or 0 if unset.
-    sighash: u32,
+    sighash_type: u32,
     bip32_count: usize,
     // Whether the input carries a *non-empty* final scriptSig or scriptWitness.
     // Emptiness rather than presence is deliberate: Bitcoin Core stores
@@ -62,38 +62,53 @@ struct OutputSummary {
 fn format_result(lock_time: u32, inputs: &[InputSummary], outputs: &[OutputSummary]) -> String {
     let mut result = String::new();
 
-    result.push_str(&format!("lt={};", lock_time));
-    result.push_str(&format!("in={};", inputs.len()));
-    result.push_str(&format!("out={};", outputs.len()));
+    result.push_str(&format!("lock_time={};", lock_time));
+    result.push_str(&format!("inputs={};", inputs.len()));
+    result.push_str(&format!("outputs={};", outputs.len()));
 
     for (i, input) in inputs.iter().enumerate() {
         result.push_str(&format!(
-            "in{}prev={}:{};",
+            "input{}previous_output={}:{};",
             i, input.prev_txid, input.prev_vout
         ));
-        let seq = input.sequence.map(|s| s.to_string()).unwrap_or_default();
-        result.push_str(&format!("in{}seq={};", i, seq));
+        let sequence = input.sequence.map(|s| s.to_string()).unwrap_or_default();
+        result.push_str(&format!("input{}sequence={};", i, sequence));
 
         if input.has_utxo {
-            result.push_str(&format!("in{}utxo=1;", i));
+            result.push_str(&format!("input{}utxo=1;", i));
         }
 
-        result.push_str(&format!("in{}sigs={};", i, input.sigs));
-        result.push_str(&format!("in{}rs={};", i, input.redeem_script_hex));
-        result.push_str(&format!("in{}ws={};", i, input.witness_script_hex));
-        result.push_str(&format!("in{}sh={};", i, input.sighash));
-        result.push_str(&format!("in{}bip32={};", i, input.bip32_count));
+        result.push_str(&format!(
+            "input{}partial_signatures={};",
+            i, input.partial_signatures
+        ));
+        result.push_str(&format!(
+            "input{}redeem_script={};",
+            i, input.redeem_script_hex
+        ));
+        result.push_str(&format!(
+            "input{}witness_script={};",
+            i, input.witness_script_hex
+        ));
+        result.push_str(&format!("input{}sighash_type={};", i, input.sighash_type));
+        result.push_str(&format!("input{}bip32={};", i, input.bip32_count));
         if input.finalized {
-            result.push_str(&format!("in{}fin=1;", i));
+            result.push_str(&format!("input{}finalized=1;", i));
         }
     }
 
     for (i, output) in outputs.iter().enumerate() {
-        result.push_str(&format!("out{}val={};", i, output.value));
-        result.push_str(&format!("out{}script={};", i, output.script_hex));
-        result.push_str(&format!("out{}rs={};", i, output.redeem_script_hex));
-        result.push_str(&format!("out{}ws={};", i, output.witness_script_hex));
-        result.push_str(&format!("out{}bip32={};", i, output.bip32_count));
+        result.push_str(&format!("output{}val={};", i, output.value));
+        result.push_str(&format!("output{}script={};", i, output.script_hex));
+        result.push_str(&format!(
+            "output{}redeem_script={};",
+            i, output.redeem_script_hex
+        ));
+        result.push_str(&format!(
+            "output{}witness_script={};",
+            i, output.witness_script_hex
+        ));
+        result.push_str(&format!("output{}bip32={};", i, output.bip32_count));
     }
 
     result
@@ -115,7 +130,7 @@ fn try_parse_v0(data: &[u8]) -> Option<String> {
             prev_vout: txin.previous_output.vout,
             sequence: Some(txin.sequence.0),
             has_utxo: psbt_input.witness_utxo.is_some() || psbt_input.non_witness_utxo.is_some(),
-            sigs: psbt_input.partial_sigs.len(),
+            partial_signatures: psbt_input.partial_sigs.len(),
             redeem_script_hex: psbt_input
                 .redeem_script
                 .as_ref()
@@ -126,7 +141,7 @@ fn try_parse_v0(data: &[u8]) -> Option<String> {
                 .as_ref()
                 .map(|s| s.to_hex_string())
                 .unwrap_or_default(),
-            sighash: psbt_input.sighash_type.map(|s| s.to_u32()).unwrap_or(0),
+            sighash_type: psbt_input.sighash_type.map(|s| s.to_u32()).unwrap_or(0),
             bip32_count: psbt_input.bip32_derivation.len(),
             finalized: psbt_input
                 .final_script_sig
@@ -260,7 +275,7 @@ fn try_parse_v2(data: &[u8]) -> Result<String, TryParseV2Error> {
             prev_vout: psbt_input.spent_output_index,
             sequence: psbt_input.sequence.map(|s| s.0),
             has_utxo: psbt_input.witness_utxo.is_some() || psbt_input.non_witness_utxo.is_some(),
-            sigs: psbt_input.partial_sigs.len(),
+            partial_signatures: psbt_input.partial_sigs.len(),
             redeem_script_hex: psbt_input
                 .redeem_script
                 .as_ref()
@@ -271,7 +286,7 @@ fn try_parse_v2(data: &[u8]) -> Result<String, TryParseV2Error> {
                 .as_ref()
                 .map(|s| s.to_hex_string())
                 .unwrap_or_default(),
-            sighash: psbt_input.sighash_type.map(|s| s.to_u32()).unwrap_or(0),
+            sighash_type: psbt_input.sighash_type.map(|s| s.to_u32()).unwrap_or(0),
             bip32_count: psbt_input.bip32_derivations.len(),
             finalized: psbt_input
                 .final_script_sig


### PR DESCRIPTION
Closes #623

- [1647a9f](https://github.com/bitcoinfuzz/bitcoinfuzz/pull/625/commits/1647a9f3a2a1608c7c05de0230d244d33bb9259e) increases verbosity of `psbt_parse` output labels as suggested in [#599](https://github.com/bitcoinfuzz/bitcoinfuzz/pull/599#discussion_r3579155304).
- [c808a13](https://github.com/bitcoinfuzz/bitcoinfuzz/pull/625/commits/c808a13644906eb0c3e0f35cfc26c269eb16e19b) returns the flag `INVALID` on failed psbt parsing for each module.

The following divergencies have been found in comparison with btccore:
- [x] [embit #149](https://github.com/diybitcoinhardware/embit/pull/149)
- [x] [libwally-core #541](https://github.com/ElementsProject/libwally-core/pull/541)
- [x] [nbitcoin #1327](https://github.com/MetacoSA/NBitcoin/pull/1327)