### PR TITLE
feat: add new target partial_merkle_tree

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -293,6 +293,10 @@ jobs:
             target: "silentpayments_create_outputs"
             cxxflags: "-DBDK_SP -DBLUEWALLET_SP -DSPDK -DSECP256K1"
             asan_options: "detect_leaks=0:detect_container_overflow=0"
+          - corpus: "partial_merkle_tree"
+            target: "partial_merkle_tree"
+            cxxflags: "-DBITCOIN_CORE -DRUST_BITCOIN"
+            asan_options: "detect_leaks=0:detect_container_overflow=0"
 
     steps:
       - name: Checkout repo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -468,6 +468,22 @@ services:
     volumes:
       - ./docker:/app/data
 
+  partial_merkle_tree:
+    build:
+      context: .
+      tags:
+        - bitcoinfuzz:partial_merkle_tree
+      args:
+        CXXFLAGS: "-DBITCOIN_CORE -DRUST_BITCOIN"
+        FUZZ: partial_merkle_tree
+    environment:
+      MODULES: ${MODULES:-}
+      LIBFUZZ_DETECT_LEAKS: 0
+      ASAN_OPTIONS: detect_leaks=0
+    env_file: .env
+    volumes:
+      - ./docker:/app/data
+
   musig2_key_agg:
     build:
       context: .

--- a/driver.cpp
+++ b/driver.cpp
@@ -789,6 +789,20 @@ void Driver::MerkleRootComputeTarget(std::span<const uint8_t> buffer) const {
   }
 }
 
+void Driver::PartialMerkleTreeTarget(std::span<const uint8_t> buffer) const {
+  std::optional<std::string> last_response{std::nullopt};
+  std::string last_module_name;
+
+  for (auto &module : modules) {
+    std::optional<std::string> res{module.second->partial_merkle_tree(buffer)};
+    if (!res.has_value())
+      continue;
+
+    VerifyMatchingResponse(last_response, last_module_name, module.first, *res,
+                           "Partial merkle tree extraction failed");
+  }
+}
+
 void Driver::Bip32DeriveFromPathTarget(std::span<const uint8_t> buffer) const {
   FuzzedDataProvider provider(buffer.data(), buffer.size());
   std::string path{provider.ConsumeRemainingBytesAsString()};
@@ -1056,6 +1070,8 @@ void Driver::Run(const uint8_t *data, const size_t size,
     this->StumpModifyAddTarget(buffer);
   } else if (target == "merkle_root_compute") {
     this->MerkleRootComputeTarget(buffer);
+  } else if (target == "partial_merkle_tree") {
+    this->PartialMerkleTreeTarget(buffer);
   } else if (target == "bip32_derive_from_path") {
     this->Bip32DeriveFromPathTarget(buffer);
   } else if (target == "musig2_key_agg") {

--- a/driver.h
+++ b/driver.h
@@ -66,6 +66,7 @@ public:
   void DecodeOnionTarget(std::span<const uint8_t> buffer) const;
   void StumpModifyAddTarget(std::span<const uint8_t> buffer) const;
   void MerkleRootComputeTarget(std::span<const uint8_t> buffer) const;
+  void PartialMerkleTreeTarget(std::span<const uint8_t> buffer) const;
   void Bip32DeriveFromPathTarget(std::span<const uint8_t> buffer) const;
   void Musig2KeyAggTarget(std::span<const uint8_t> buffer) const;
   void Aes256CbcTarget(std::span<const uint8_t> buffer) const;

--- a/include/bitcoinfuzz/basemodule.cpp
+++ b/include/bitcoinfuzz/basemodule.cpp
@@ -178,6 +178,11 @@ std::optional<std::string> BaseModule::merkle_root_compute(
 }
 
 std::optional<std::string>
+BaseModule::partial_merkle_tree(std::span<const uint8_t> /*buffer*/) const {
+  return std::nullopt;
+}
+
+std::optional<std::string>
 BaseModule::bip32_derive_from_path(std::span<const uint8_t> /*buffer*/) const {
   return std::nullopt;
 }

--- a/include/bitcoinfuzz/basemodule.h
+++ b/include/bitcoinfuzz/basemodule.h
@@ -145,6 +145,21 @@ public:
   // all (e.g. rust-bitcoin returns None for mutated lists).
   virtual std::optional<std::string>
   merkle_root_compute(const std::vector<std::vector<uint8_t>> &hashes) const;
+  // Parses a BIP37 partial Merkle tree (nTransactions u32 LE | CompactSize n
+  // | n*32-byte hashes | CompactSize m | m flag bytes) and extracts the
+  // matched transactions, emulating CMerkleBlock extraction semantics.
+  // Returns one of:
+  //   "PARSE_ERR"  — the byte stream is malformed (truncated, non-canonical
+  //                  CompactSize, ...)
+  //   "REJECT"     — parsed but the tree is invalid (Core's ExtractMatches
+  //                  returning the zero hash; covers nTransactions==0,
+  //                  too many transactions/hashes, bit/hash underflow during
+  //                  traversal, CVE-2012-2459 duplicated branches, trailing
+  //                  unconsumed bits or hashes)
+  //   "<root_hex>;m=<txid>@<idx>,..." — root and matched txids with their
+  //                  leaf indices, in traversal order (display byte order)
+  virtual std::optional<std::string>
+  partial_merkle_tree(std::span<const uint8_t> buffer) const;
 
   virtual std::optional<std::string>
   bip32_derive_from_path(std::span<const uint8_t> buffer) const;

--- a/modules/bitcoin/Makefile
+++ b/modules/bitcoin/Makefile
@@ -84,6 +84,7 @@ BITCOIN_SRCS := \
     key.cpp \
     key_io.cpp \
     logging.cpp \
+    merkleblock.cpp \
     musig.cpp \
     netaddress.cpp \
     outputtype.cpp \

--- a/modules/bitcoin/module.cpp
+++ b/modules/bitcoin/module.cpp
@@ -17,6 +17,7 @@ const TranslateFn G_TRANSLATION_FUN{nullptr};
 #include "descriptor.h"
 #include "key.h"
 #include "key_io.h"
+#include "merkleblock.h"
 #include "module.h"
 #include "primitives/block.h"
 #include "primitives/transaction.h"
@@ -431,6 +432,34 @@ std::optional<std::string> Bitcoin::merkle_root_compute(
 
   // Root in display byte order, plus the CVE-2012-2459 mutation flag.
   return root.ToString() + ";mutated=" + (mutated ? "1" : "0");
+}
+
+std::optional<std::string>
+Bitcoin::partial_merkle_tree(std::span<const uint8_t> buffer) const {
+  DataStream ds{buffer};
+  CPartialMerkleTree pmt;
+  try {
+    ds >> pmt;
+  } catch (const std::ios_base::failure &e) {
+    return "PARSE_ERR";
+  }
+
+  std::vector<Txid> matches;
+  std::vector<unsigned int> indexes;
+  const uint256 root{pmt.ExtractMatches(matches, indexes)};
+  // ExtractMatches returns the zero hash for every failure mode
+  // (bad structure, CVE-2012-2459 duplicated branch, unconsumed bits/hashes).
+  if (root.IsNull()) {
+    return "REJECT";
+  }
+
+  std::string res{root.ToString() + ";m="};
+  for (size_t i = 0; i < matches.size(); ++i) {
+    res += matches[i].ToString() + "@" + std::to_string(indexes[i]);
+    if (i + 1 < matches.size())
+      res += ",";
+  }
+  return res;
 }
 
 std::optional<std::string> Bitcoin::address_parse(std::string str) const {

--- a/modules/bitcoin/module.h
+++ b/modules/bitcoin/module.h
@@ -34,6 +34,8 @@ public:
   std::optional<std::string> merkle_root_compute(
       const std::vector<std::vector<uint8_t>> &hashes) const override;
   std::optional<std::string>
+  partial_merkle_tree(std::span<const uint8_t> buffer) const override;
+  std::optional<std::string>
   bip32_master_keygen(std::span<const uint8_t> buffer) const override;
   std::optional<std::string> bip32_deserialize_extended_key(
       std::span<const uint8_t> buffer) const override;

--- a/modules/rustbitcoin/module.cpp
+++ b/modules/rustbitcoin/module.cpp
@@ -150,6 +150,19 @@ std::optional<std::string> Rustbitcoin::merkle_root_compute(
   auto result_ptr = rust_bitcoin_merkle_root_compute(flat.data(), flat.size());
   if (result_ptr == nullptr)
     return std::nullopt;
+
+  std::string result(result_ptr);
+  free_c_string(result_ptr);
+  return result;
+}
+
+std::optional<std::string>
+Rustbitcoin::partial_merkle_tree(std::span<const uint8_t> buffer) const {
+  auto result_ptr =
+      rust_bitcoin_partial_merkle_tree(buffer.data(), buffer.size());
+  if (result_ptr == nullptr)
+    return std::nullopt;
+
   std::string result(result_ptr);
   free_c_string(result_ptr);
   return result;

--- a/modules/rustbitcoin/module.h
+++ b/modules/rustbitcoin/module.h
@@ -36,6 +36,8 @@ public:
   roundtrip_ellswift(std::span<const uint8_t> privkey) const override;
   std::optional<std::string> merkle_root_compute(
       const std::vector<std::vector<uint8_t>> &hashes) const override;
+  std::optional<std::string>
+  partial_merkle_tree(std::span<const uint8_t> buffer) const override;
   ~Rustbitcoin() noexcept override = default;
 };
 

--- a/modules/rustbitcoin/rust_bitcoin_lib/rust_bitcoin_lib.h
+++ b/modules/rustbitcoin/rust_bitcoin_lib/rust_bitcoin_lib.h
@@ -21,3 +21,5 @@ extern "C" char *rust_bitcoin_roundtrip_ellswift(const uint8_t *data,
                                                  size_t len);
 extern "C" char *rust_bitcoin_merkle_root_compute(const uint8_t *data,
                                                   size_t len);
+extern "C" char *rust_bitcoin_partial_merkle_tree(const uint8_t *data,
+                                                  size_t len);

--- a/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
+++ b/modules/rustbitcoin/rust_bitcoin_lib/src/lib.rs
@@ -399,6 +399,48 @@ pub unsafe extern "C" fn rust_bitcoin_merkle_root_compute(
     }
 }
 
+/// Parses a BIP37 partial Merkle tree (nTransactions | hashes | flag bytes)
+/// and extracts the matched transactions, mirroring Bitcoin Core's
+/// CPartialMerkleTree::ExtractMatches. Trailing bytes are tolerated, matching
+/// Core's DataStream behavior. Rejection reasons are normalized to "REJECT"
+/// because Core collapses all of them into a zero-hash return.
+#[no_mangle]
+pub unsafe extern "C" fn rust_bitcoin_partial_merkle_tree(
+    data: *const u8,
+    len: usize,
+) -> *mut c_char {
+    let data_slice = slice::from_raw_parts(data, len);
+    let mut cursor = data_slice;
+    let pmt = match decode_from_slice_unbounded::<p2p::merkle_tree::PartialMerkleTree>(&mut cursor)
+    {
+        Ok(pmt) => pmt,
+        Err(_) => return str_to_c_string("PARSE_ERR"),
+    };
+
+    let mut matches: Vec<bitcoin::Txid> = Vec::new();
+    let mut indexes: Vec<u32> = Vec::new();
+    match pmt.extract_matches(&mut matches, &mut indexes) {
+        Err(_) => str_to_c_string("REJECT"),
+        Ok(root) => {
+            // Core signals every extraction failure with the zero hash, so a
+            // zero root is indistinguishable from rejection in its API (and
+            // is treated as rejection by all its callers); map to the same
+            // sentinel for comparability.
+            if root == bitcoin::TxMerkleNode::from_byte_array([0u8; 32]) {
+                return str_to_c_string("REJECT");
+            }
+            let mut result = format!("{};m=", root);
+            for (i, (txid, idx)) in matches.iter().zip(indexes.iter()).enumerate() {
+                if i > 0 {
+                    result.push(',');
+                }
+                result.push_str(&format!("{}@{}", txid, idx));
+            }
+            str_to_c_string(&result)
+        }
+    }
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn rust_bitcoin_bip32_master_keygen(
     data: *const u8,


### PR DESCRIPTION
Differential fuzzing of BIP37 partial Merkle tree extraction: parse a serialized CPartialMerkleTree body (nTransactions | hashes | flag bytes) and compare the reconstructed root plus the matched txids and their leaf indices. Rejection is normalized to "REJECT" (Core collapses all failure modes into a zero-hash return) and stream-level malformation to "PARSE_ERR"; trailing garbage is tolerated on both sides (matches Core's DataStream behavior).

This covers the CVE-2012-2459 duplicated-branch check at the SPV-proof layer (the haskoin-core finding class), which merkle_root_compute does not reach: Core rejects when a descended branch's children are identical, and never descends into fully-unmatched subtrees (so duplicated leaves that are never traversed still verify).

Modules: BITCOIN_CORE (CPartialMerkleTree::ExtractMatches; merkleblock.cpp added to the module build) and RUST_BITCOIN (p2p crate's PartialMerkleTree, which ports Core's checks one-to-one including IdenticalHashesFound). btcd and gocoin have no native partial-tree extraction API, so they are intentionally out of scope (a wrapper-side traversal would only test our own reimplementation).

Fuzzing immediately found a harness-level ambiguity, fixed before commit: a 1-transaction tree whose only hash is all-zero yields a legitimate zero root. Core cannot represent that as success (zero hash is its failure sentinel), so rust-bitcoin's Ok(zero) is normalized to "REJECT" as well.

Validated in Docker (linux/amd64): 46 known-answer vectors against an independent Python port of Core's build/extract (valid trees for 1-8 txids with assorted match masks, matched/unmatched duplicated branches, zero nTransactions, too many hashes, unconsumed bits/hashes, truncated and non-canonical CompactSize, padding-bit tolerance, zero-root regression); plus a seeded 300s run: ~895k execs, no mismatches.