### PR TITLE
embit: ignore if bip32 fuzz input fails to decode

### DIFF
--- a/modules/embit/embit_lib.py
+++ b/modules/embit/embit_lib.py
@@ -135,9 +135,8 @@ def bip32_master_keygen(data):
 
 
 def bip32_deserialize_extended_key(data: str) -> str:
-
-    data = data.decode()
     try:
+        data = data.decode()
         key: HDKey = HDKey.from_base58(data)
     except Exception:
         return "INVALID"


### PR DESCRIPTION
This was needed to find the bugs I mentioned in #641.

Without this, I think the `bip32_deserialize_extended_key` target for embit is broken. 