### PR TITLE
refactor: set PYTHON_LDFLAGS once in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,16 +176,8 @@ ifneq ($(findstring -DTINY_MINISCRIPT,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
   TINY_MINISCRIPT_LIB := ./libtiny_miniscript_lib.$(LIB_EXT)
 endif
 
-# Check for EMBIT define and add Python-related flags
-ifneq ($(findstring -DEMBIT,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
-  PYTHON_LDFLAGS := $(shell python3-config --ldflags --embed)
-endif
-
-ifneq ($(findstring -DPYBITCOINKERNEL,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
-  PYTHON_LDFLAGS := $(shell python3-config --ldflags --embed)
-endif
-
-ifneq ($(findstring -DPYCOIN,$(BASE_CXXFLAGS) $(CXXFLAGS)),)
+# Check for Python-based modules and add Python-related flags.
+ifneq (,$(filter -DEMBIT -DPYBITCOINKERNEL -DPYCOIN,$(BASE_CXXFLAGS) $(CXXFLAGS)))
   PYTHON_LDFLAGS := $(shell python3-config --ldflags --embed)
 endif
 


### PR DESCRIPTION
I was about to add another similar block in #641, but Claude and I think this should do the same thing, and then I can just add `-DELECTRUM` in #641.

_Btw, Claude also flexed that `filter` is superior to `findstring` because it matches whole words rather than substrings, haha_