### PR TITLE
Add `transaction_eval` target to bitcoinkernel module

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -259,7 +259,7 @@ jobs:
             setup_java: "true"
           - corpus: "transaction_eval"
             target: "transaction_eval"
-            cxxflags: "-DBITCOIN_CORE -DBTCD -DLIBBITCOIN_SYSTEM"
+            cxxflags: "-DBITCOIN_CORE -DBITCOINKERNEL -DBTCD -DLIBBITCOIN_SYSTEM"
             asan_options: "detect_leaks=0:detect_container_overflow=0"
           - corpus: "decode_ellswift"
             target: "decode_ellswift"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -203,7 +203,7 @@ services:
       tags:
         - bitcoinfuzz:transaction_eval
       args:
-        CXXFLAGS: "-DBITCOIN_CORE -DBTCD"
+        CXXFLAGS: "-DBITCOIN_CORE -DBITCOINKERNEL -DBTCD"
         FUZZ: transaction_eval
     env_file: .env
     environment:

--- a/modules/bitcoinkernel/Makefile
+++ b/modules/bitcoinkernel/Makefile
@@ -64,9 +64,8 @@ $(KERNEL_LIB): bitcoin-sync
 		-DENABLE_WALLET=OFF \
 		-DBUILD_WALLET_TOOL=OFF \
 		-DENABLE_EXTERNAL_SIGNER=OFF \
-		-DSANITIZERS=fuzzer \
-	cd $(BITCOIN_DIR) && \
-	cmake --build build-kernel -j"$$(nproc)" --target bitcoinkernel
+		-DSANITIZERS=fuzzer
+	cmake --build $(KERNEL_BUILD_DIR) -j"$$(nproc)" --target bitcoinkernel
 
 bitcoin-sync:
 	@if [ ! -d "$(BITCOIN_DIR)/.git" ]; then \

--- a/modules/bitcoinkernel/module.cpp
+++ b/modules/bitcoinkernel/module.cpp
@@ -7,28 +7,29 @@
 #include <cstdint>
 #include <cstring>
 #include <iomanip>
+#include <ranges>
 #include <span>
 #include <sstream>
 #include <string>
 
 namespace {
-std::string bytes_to_hex(const uint8_t *bytes, int length) {
+std::string bytes_to_hex(std::span<const std::byte> bytes) {
   std::stringstream string_stream;
   string_stream << std::hex;
-  for (int i = 0; i < length; ++i) {
+  for (const auto byte : bytes) {
     string_stream << std::setw(2) << std::setfill('0')
-                  << static_cast<int>(bytes[i]);
+                  << std::to_integer<int>(byte);
   }
 
   return string_stream.str();
 }
 
-std::string hash_bytes_to_hex(const uint8_t *bytes, int length) {
+std::string hash_bytes_to_hex(std::span<const std::byte> bytes) {
   std::stringstream string_stream;
   string_stream << std::hex;
-  for (int i = length - 1; i >= 0; --i) {
+  for (const auto byte : bytes | std::views::reverse) {
     string_stream << std::setw(2) << std::setfill('0')
-                  << static_cast<int>(bytes[i]);
+                  << std::to_integer<int>(byte);
   }
 
   return string_stream.str();
@@ -70,14 +71,12 @@ btck::BlockCheckFlags decode_block_check_flags(uint8_t value) {
 
 char *libbitcoinkernel_transaction(std::span<const uint8_t> buffer) {
   try {
-    std::span<const std::byte> raw_span{(const std::byte *)buffer.data(),
-                                        buffer.size()};
+    const auto raw_span = std::as_bytes(buffer);
     btck::Transaction transaction{raw_span};
 
     const auto txid_bytes = transaction.Txid().ToBytes();
     std::string result = "txid=";
-    result.append(hash_bytes_to_hex((const uint8_t *)txid_bytes.data(),
-                                    static_cast<int>(txid_bytes.size())));
+    result.append(hash_bytes_to_hex(txid_bytes));
     result.append(";");
 
     const auto txins = transaction.Inputs();
@@ -88,9 +87,7 @@ char *libbitcoinkernel_transaction(std::span<const uint8_t> buffer) {
       result.append("index=");
       result.append(std::to_string(outpoint_index));
       result.append("txid=");
-      result.append(
-          hash_bytes_to_hex((const uint8_t *)outpoint_txid_bytes.data(),
-                            static_cast<int>(outpoint_txid_bytes.size())));
+      result.append(hash_bytes_to_hex(outpoint_txid_bytes));
       result.append(";");
     }
 
@@ -101,8 +98,7 @@ char *libbitcoinkernel_transaction(std::span<const uint8_t> buffer) {
       result.append("amount=");
       result.append(std::to_string(txout_amount));
       result.append("script_pubkey=");
-      result.append(bytes_to_hex((const uint8_t *)script_pubkey_bytes.data(),
-                                 static_cast<int>(script_pubkey_bytes.size())));
+      result.append(bytes_to_hex(script_pubkey_bytes));
       result.append(";");
     }
     return strdup(result.c_str());
@@ -113,21 +109,17 @@ char *libbitcoinkernel_transaction(std::span<const uint8_t> buffer) {
 
 char *libbitcoinkernel_block(std::span<const uint8_t> buffer) {
   try {
-    std::span<const std::byte> raw_span{(const std::byte *)buffer.data(),
-                                        buffer.size()};
+    const auto raw_span = std::as_bytes(buffer);
     btck::Block block{raw_span};
 
     const auto block_hash_bytes = block.GetHash().ToBytes();
-    std::string result =
-        hash_bytes_to_hex((const uint8_t *)block_hash_bytes.data(),
-                          static_cast<int>(block_hash_bytes.size()));
+    std::string result = hash_bytes_to_hex(block_hash_bytes);
 
     const auto txs = block.Transactions();
     for (const auto &tx : txs) {
       const auto txid_bytes = tx.Txid().ToBytes();
       result.append("txid=");
-      result.append(hash_bytes_to_hex((const uint8_t *)txid_bytes.data(),
-                                      static_cast<int>(txid_bytes.size())));
+      result.append(hash_bytes_to_hex(txid_bytes));
       result.push_back(';');
     }
     return strdup(result.c_str());
@@ -153,8 +145,7 @@ char *libbitcoinkernel_block_check(std::span<const uint8_t> buffer) {
 
   try {
     btck::ChainParams chain_params{chain_type};
-    std::span<const std::byte> raw_span{(const std::byte *)raw_block.data(),
-                                        raw_block.size()};
+    const auto raw_span = std::as_bytes(raw_block);
     btck::Block block{raw_span};
     btck::BlockValidationState state{};
     const bool ok =
@@ -169,8 +160,7 @@ char *libbitcoinkernel_block_check(std::span<const uint8_t> buffer) {
         std::to_string(static_cast<int>(state.GetBlockValidationResult())));
     result.append(";hash=");
     const auto block_hash_bytes = block.GetHash().ToBytes();
-    result.append(hash_bytes_to_hex((const uint8_t *)block_hash_bytes.data(),
-                                    static_cast<int>(block_hash_bytes.size())));
+    result.append(hash_bytes_to_hex(block_hash_bytes));
     result.append(";txs=");
     result.append(std::to_string(block.CountTransactions()));
     result.push_back(';');

--- a/modules/bitcoinkernel/module.cpp
+++ b/modules/bitcoinkernel/module.cpp
@@ -1,4 +1,6 @@
 #include "module.h"
+
+#include <hash.h>
 #include <kernel/bitcoinkernel_wrapper.h>
 
 #include <array>
@@ -170,6 +172,52 @@ char *libbitcoinkernel_block_check(std::span<const uint8_t> buffer) {
     return strdup(result.c_str());
   }
 }
+
+char *libbitcoinkernel_transaction_eval(std::span<const uint8_t> buffer) {
+  try {
+    const auto raw_span = std::as_bytes(buffer);
+    btck::Transaction transaction{raw_span};
+    btck::TxValidationState state{};
+    if (!btck::CheckTransaction(transaction, state))
+      return strdup("0");
+
+    // Since bitcoinkernel does not provide a public interface for getting the
+    // witness hash, we calculate it manually using core's internal API.
+    // TODO: Swap wtxid calculation for kernel's getter when it becomes
+    // available.
+    //
+    // Check if the transaction has witness data to avoid unnecessary
+    // hashing in the case of non-witness-transactions.
+    bool has_witness{false};
+    for (const auto &input : transaction.Inputs()) {
+      if (input.GetWitnessStack().CountItems() != 0) {
+        has_witness = true;
+        break;
+      }
+    }
+
+    // ToBytes() serializes the transaction using TX_WITH_WITNESS
+    // serialization-parameter object, so we can hash the serialized bytes.
+    const auto transaction_bytes = transaction.ToBytes();
+    std::array<unsigned char, CHash256::OUTPUT_SIZE> witness_hash{};
+    if (!has_witness) {
+      const auto txid = transaction.Txid().ToBytes();
+      std::memcpy(witness_hash.data(), txid.data(), txid.size());
+    } else {
+      const std::span<const unsigned char> hash_input{
+          reinterpret_cast<const unsigned char *>(transaction_bytes.data()),
+          transaction_bytes.size()};
+      CHash256{}.Write(hash_input).Finalize(witness_hash);
+    }
+
+    std::string result =
+        hash_bytes_to_hex(std::as_bytes(std::span{witness_hash}));
+    result += std::to_string(transaction_bytes.size());
+    return strdup(result.c_str());
+  } catch (...) {
+    return strdup("0");
+  }
+}
 } // namespace
 
 namespace bitcoinfuzz {
@@ -201,6 +249,17 @@ BitcoinKernel::kernel_block(std::span<const uint8_t> buffer) const {
 std::optional<std::string>
 BitcoinKernel::kernel_block_check(std::span<const uint8_t> buffer) const {
   auto result_ptr = libbitcoinkernel_block_check(buffer);
+  if (result_ptr == nullptr)
+    return std::nullopt;
+
+  std::string result(result_ptr);
+  free(result_ptr);
+  return result;
+}
+
+std::optional<std::string>
+BitcoinKernel::transaction_eval(std::span<const uint8_t> buffer) const {
+  auto result_ptr = libbitcoinkernel_transaction_eval(buffer);
   if (result_ptr == nullptr)
     return std::nullopt;
 

--- a/modules/bitcoinkernel/module.h
+++ b/modules/bitcoinkernel/module.h
@@ -12,6 +12,10 @@ public:
   kernel_transaction(std::span<const uint8_t> buffer) const override;
   std::optional<std::string>
   kernel_block_check(std::span<const uint8_t> buffer) const override;
+  // Core target to compare core's internal
+  // behaviour with the public kernel ABI.
+  std::optional<std::string>
+  transaction_eval(std::span<const uint8_t> buffer) const override;
   ~BitcoinKernel() noexcept override = default;
 };
 

--- a/modules/bitcoinkernelvariant/module.cpp
+++ b/modules/bitcoinkernelvariant/module.cpp
@@ -8,28 +8,29 @@
 #include <cstdint>
 #include <cstring>
 #include <iomanip>
+#include <ranges>
 #include <span>
 #include <sstream>
 #include <string>
 
 namespace {
-std::string bytes_to_hex(const uint8_t *bytes, int lenght) {
+std::string bytes_to_hex(std::span<const std::byte> bytes) {
   std::stringstream string_stream;
   string_stream << std::hex;
-  for (int i = 0; i < lenght; ++i) {
+  for (const auto byte : bytes) {
     string_stream << std::setw(2) << std::setfill('0')
-                  << static_cast<int>(bytes[i]);
+                  << std::to_integer<int>(byte);
   }
 
   return string_stream.str();
 }
 
-std::string hash_bytes_to_hex(const uint8_t *bytes, int length) {
+std::string hash_bytes_to_hex(std::span<const std::byte> bytes) {
   std::stringstream string_stream;
   string_stream << std::hex;
-  for (int i = length - 1; i >= 0; --i) {
+  for (const auto byte : bytes | std::views::reverse) {
     string_stream << std::setw(2) << std::setfill('0')
-                  << static_cast<int>(bytes[i]);
+                  << std::to_integer<int>(byte);
   }
 
   return string_stream.str();
@@ -71,14 +72,12 @@ btck::BlockCheckFlags decode_block_check_flags(uint8_t value) {
 
 char *libbitcoinkernel_transaction(std::span<const uint8_t> buffer) {
   try {
-    std::span<const std::byte> raw_span{(const std::byte *)buffer.data(),
-                                        buffer.size()};
+    const auto raw_span = std::as_bytes(buffer);
     btck::Transaction transaction{raw_span};
 
     const auto txid_bytes = transaction.Txid().ToBytes();
     std::string result = "txid=";
-    result.append(hash_bytes_to_hex((const uint8_t *)txid_bytes.data(),
-                                    static_cast<int>(txid_bytes.size())));
+    result.append(hash_bytes_to_hex(txid_bytes));
     result.append(";");
 
     const auto txins = transaction.Inputs();
@@ -89,9 +88,7 @@ char *libbitcoinkernel_transaction(std::span<const uint8_t> buffer) {
       result.append("index=");
       result.append(std::to_string(outpoint_index));
       result.append("txid=");
-      result.append(
-          hash_bytes_to_hex((const uint8_t *)outpoint_txid_bytes.data(),
-                            static_cast<int>(outpoint_txid_bytes.size())));
+      result.append(hash_bytes_to_hex(outpoint_txid_bytes));
       result.append(";");
     }
 
@@ -102,8 +99,7 @@ char *libbitcoinkernel_transaction(std::span<const uint8_t> buffer) {
       result.append("amount=");
       result.append(std::to_string(txout_amount));
       result.append("script_pubkey=");
-      result.append(bytes_to_hex((const uint8_t *)script_pubkey_bytes.data(),
-                                 static_cast<int>(script_pubkey_bytes.size())));
+      result.append(bytes_to_hex(script_pubkey_bytes));
       result.append(";");
     }
     return strdup(result.c_str());
@@ -114,21 +110,17 @@ char *libbitcoinkernel_transaction(std::span<const uint8_t> buffer) {
 
 char *libbitcoinkernel_block(std::span<const uint8_t> buffer) {
   try {
-    std::span<const std::byte> raw_span{(const std::byte *)buffer.data(),
-                                        buffer.size()};
+    const auto raw_span = std::as_bytes(buffer);
     btck::Block block{raw_span};
 
     const auto block_hash_bytes = block.GetHash().ToBytes();
-    std::string result =
-        hash_bytes_to_hex((const uint8_t *)block_hash_bytes.data(),
-                          static_cast<int>(block_hash_bytes.size()));
+    std::string result = hash_bytes_to_hex(block_hash_bytes);
 
     const auto txs = block.Transactions();
     for (const auto &tx : txs) {
       const auto txid_bytes = tx.Txid().ToBytes();
       result.append("txid=");
-      result.append(hash_bytes_to_hex((const uint8_t *)txid_bytes.data(),
-                                      static_cast<int>(txid_bytes.size())));
+      result.append(hash_bytes_to_hex(txid_bytes));
       result.push_back(';');
     }
     return strdup(result.c_str());
@@ -154,8 +146,7 @@ char *libbitcoinkernel_block_check(std::span<const uint8_t> buffer) {
 
   try {
     btck::ChainParams chain_params{chain_type};
-    std::span<const std::byte> raw_span{(const std::byte *)raw_block.data(),
-                                        raw_block.size()};
+    const auto raw_span = std::as_bytes(raw_block);
     btck::Block block{raw_span};
     btck::BlockValidationState state{};
     const bool ok =
@@ -170,8 +161,7 @@ char *libbitcoinkernel_block_check(std::span<const uint8_t> buffer) {
         std::to_string(static_cast<int>(state.GetBlockValidationResult())));
     result.append(";hash=");
     const auto block_hash_bytes = block.GetHash().ToBytes();
-    result.append(hash_bytes_to_hex((const uint8_t *)block_hash_bytes.data(),
-                                    static_cast<int>(block_hash_bytes.size())));
+    result.append(hash_bytes_to_hex(block_hash_bytes));
     result.append(";txs=");
     result.append(std::to_string(block.CountTransactions()));
     result.push_back(';');

--- a/modules/bitcoinkernelvariant/module.cpp
+++ b/modules/bitcoinkernelvariant/module.cpp
@@ -1,5 +1,7 @@
 #include "module.h"
 #include "bitcoinkernel_variant_symbol_prefix.h"
+
+#include <hash.h>
 #include <kernel/bitcoinkernel_wrapper.h>
 
 #include <array>
@@ -171,6 +173,52 @@ char *libbitcoinkernel_block_check(std::span<const uint8_t> buffer) {
     return strdup(result.c_str());
   }
 }
+
+char *libbitcoinkernel_transaction_eval(std::span<const uint8_t> buffer) {
+  try {
+    const auto raw_span = std::as_bytes(buffer);
+    btck::Transaction transaction{raw_span};
+    btck::TxValidationState state{};
+    if (!btck::CheckTransaction(transaction, state))
+      return strdup("0");
+
+    // Since bitcoinkernel does not provide a public interface for getting the
+    // witness hash, we calculate it manually using core's internal API.
+    // TODO: Swap wtxid calculation for kernel's getter when it becomes
+    // available.
+    //
+    // Check if the transaction has witness data to avoid unnecessary
+    // hashing in the case of non-witness-transactions.
+    bool has_witness{false};
+    for (const auto &input : transaction.Inputs()) {
+      if (input.GetWitnessStack().CountItems() != 0) {
+        has_witness = true;
+        break;
+      }
+    }
+
+    // ToBytes() serializes the transaction using TX_WITH_WITNESS
+    // serialization-parameter object, so we can hash the serialized bytes.
+    const auto transaction_bytes = transaction.ToBytes();
+    std::array<unsigned char, CHash256::OUTPUT_SIZE> witness_hash{};
+    if (!has_witness) {
+      const auto txid = transaction.Txid().ToBytes();
+      std::memcpy(witness_hash.data(), txid.data(), txid.size());
+    } else {
+      const std::span<const unsigned char> hash_input{
+          reinterpret_cast<const unsigned char *>(transaction_bytes.data()),
+          transaction_bytes.size()};
+      CHash256{}.Write(hash_input).Finalize(witness_hash);
+    }
+
+    std::string result =
+        hash_bytes_to_hex(std::as_bytes(std::span{witness_hash}));
+    result += std::to_string(transaction_bytes.size());
+    return strdup(result.c_str());
+  } catch (...) {
+    return strdup("0");
+  }
+}
 } // namespace
 
 namespace bitcoinfuzz {
@@ -203,6 +251,17 @@ BitcoinKernelVariant::kernel_block(std::span<const uint8_t> buffer) const {
 std::optional<std::string> BitcoinKernelVariant::kernel_block_check(
     std::span<const uint8_t> buffer) const {
   auto result_ptr = libbitcoinkernel_block_check(buffer);
+  if (result_ptr == nullptr)
+    return std::nullopt;
+
+  std::string result(result_ptr);
+  free(result_ptr);
+  return result;
+}
+
+std::optional<std::string>
+BitcoinKernelVariant::transaction_eval(std::span<const uint8_t> buffer) const {
+  auto result_ptr = libbitcoinkernel_transaction_eval(buffer);
   if (result_ptr == nullptr)
     return std::nullopt;
 

--- a/modules/bitcoinkernelvariant/module.h
+++ b/modules/bitcoinkernelvariant/module.h
@@ -12,6 +12,10 @@ public:
   kernel_transaction(std::span<const uint8_t> buffer) const override;
   std::optional<std::string>
   kernel_block_check(std::span<const uint8_t> buffer) const override;
+  // Core target to compare core's internal
+  // behaviour with the public kernel ABI.
+  std::optional<std::string>
+  transaction_eval(std::span<const uint8_t> buffer) const override;
   ~BitcoinKernelVariant() noexcept override = default;
 };
 


### PR DESCRIPTION
Adds the `transaction_eval` target to the bitcoinkernel module so that core's bitcoinkernel ABI can be tested against its own internal behaviour.

I've intentionally not added the target to the other kernel bindings as that's what the `kernel_*` targets are for, comparing external consumers of the public bitcoinkernel interface. This PR aims to cover the specific case where a kernel functionality might not be correctly exposed through btccore's own public kernel ABI.